### PR TITLE
Switch to a Simple build system

### DIFF
--- a/haskell-src-exts.cabal
+++ b/haskell-src-exts.cabal
@@ -2,6 +2,7 @@ Name:                   haskell-src-exts
 Version:                1.14.0
 License:                BSD3
 License-File:           LICENSE
+Build-Type:             Simple
 Author:                 Niklas Broberg
 Maintainer:             Niklas Broberg <niklas.broberg@chalmers.se>
 Category:               Language


### PR DESCRIPTION
Allows haskell-src-exts to compile using Cabal 1.16 on GHC 7.2
