### PR TITLE
Use "is not enabled" for all extension error messages

### DIFF
--- a/src/Language/Haskell/Exts/ParseUtils.hs
+++ b/src/Language/Haskell/Exts/ParseUtils.hs
@@ -209,7 +209,7 @@ checkAsstParam isSimple t = do
                         f <- checkAsstParam isSimple pf
                         t <- checkType pt
                         return $ S.TyApp l f t
-                _       -> fail "Malformed context: FlexibleContexts not enabled"
+                _       -> fail "Malformed context: FlexibleContexts is not enabled"
 
 -----------------------------------------------------------------------------
 -- Checking Headers


### PR DESCRIPTION
To print in the same style as in `checkEnabled`.
