### PR TITLE
Fixed processing of Unicode forall.

### DIFF
--- a/Test/examples/UnicodeSyntax.hs
+++ b/Test/examples/UnicodeSyntax.hs
@@ -1,14 +1,14 @@
-{-# LANGUAGE UnicodeSyntax, ExplicitForall #-}
+{-# LANGUAGE UnicodeSyntax, ExplicitForAll #-}
 module UnicodeSyntax where
 
 import System.Environment (getArgs)
 
-main :: IO ()
+main ∷ IO ()
 main = do
   as ← getArgs
   print $ test 0
 
-test :: Int → Bool
+test ∷ Int → Bool
 test x = x*5 == x+8
 
 id1 ∷ ∀ a . a → a

--- a/Test/failing.txt
+++ b/Test/failing.txt
@@ -9,7 +9,6 @@ BadStringLineBreak.hs	 Shouldn't succeed.
 NonDecreasing.hs	 Shouldn't succeed without -XNondecreasingIndentation.
 THTypes.hs		 Type splices not yet supported
 QQType.hs                Same issue as above
-UnicodeSyntax.hs         Unicode forall symbol not working
 IllDataTypeDecl.hs       Parser doesn't handle all declaration heads
 ConstraintKinds.hs       ConstraintKinds in type synonyms not yet supported.
 RCategory.lhs            ConstraintKinds not supported in general.

--- a/src/Language/Haskell/Exts/InternalLexer.hs
+++ b/src/Language/Haskell/Exts/InternalLexer.hs
@@ -228,7 +228,8 @@ reserved_ops = [
  ( "\x291a",    (RightArrowTail,    Just (All [UnicodeSyntax, Arrows])) ),
  ( "\x291b",    (LeftDblArrowTail,  Just (All [UnicodeSyntax, Arrows])) ),
  ( "\x291c",    (RightDblArrowTail, Just (All [UnicodeSyntax, Arrows])) ),
- ( "\x2605",    (Star,              Just (All [UnicodeSyntax, KindSignatures])) )
+ ( "\x2605",    (Star,              Just (All [UnicodeSyntax, KindSignatures])) ),
+ ( "\x2200",    (KW_Forall,         Just (All [UnicodeSyntax, ExplicitForAll])) )
  ]
 
 special_varops :: [(String,(Token, Maybe ExtScheme))]
@@ -273,10 +274,7 @@ reserved_ids = [
  ( "where",     (KW_Where,      Nothing) ),
 
 -- FFI
- ( "foreign",   (KW_Foreign,    Just (Any [ForeignFunctionInterface])) ),
-
--- Unicode
- ( "\x2200",    (KW_Forall,     Just (All [UnicodeSyntax, ExplicitForAll])) )
+ ( "foreign",   (KW_Foreign,    Just (Any [ForeignFunctionInterface])) )
  ]
 
 


### PR DESCRIPTION
In GHC 7.6.3 (file `compiler/parser/Lexer.x.source`), ∀ is not in `reservedWordsFM` but `reservedSymsFM`. I made the corresponding change in `Language.Haskell.Exts.InternalLexer`.
