### PR TITLE
Fix Non-exhaustive pattern in pretty

### DIFF
--- a/src/Language/Haskell/Exts/Pretty.hs
+++ b/src/Language/Haskell/Exts/Pretty.hs
@@ -602,6 +602,7 @@ instance Pretty CallConv where
         pretty DotNet    = text "dotnet"
         pretty Jvm       = text "jvm"
         pretty Js        = text "js"
+        pretty CApi      = text "capi"
 
 ------------------------- Pragmas ---------------------------------------
 ppWarnDepr :: ([Name], String) -> Doc


### PR DESCRIPTION
In the instance for CallConv CApi was missing.
