### PR TITLE
More compact Show instance for SrcSpan

### DIFF
--- a/src/Language/Haskell/Exts/SrcLoc.hs
+++ b/src/Language/Haskell/Exts/SrcLoc.hs
@@ -41,7 +41,7 @@ data SrcSpan = SrcSpan
   deriving (Eq,Ord,Typeable,Data)
 
 instance Show SrcSpan where
-  show (SrcSpan fn sl sc el ec) = "SrcSpan " ++ fn ++ " " ++ (intercalate " " $ map show [sl,sc,el,ec])
+  show (SrcSpan fn sl sc el ec) = "SrcSpan " ++ show fn ++ " " ++ (intercalate " " $ map show [sl,sc,el,ec])
 
 
 -- | Returns 'srcSpanStartLine' and 'srcSpanStartColumn' in a pair.


### PR DESCRIPTION
The default Show instance for SrcSpan is very verbose.

This is an equivalent one relying on positional information rather than named constructors.
