### PR TITLE
Omit parentheses when pretty-printing single member contexts.

### DIFF
--- a/src/Language/Haskell/Exts/Pretty.hs
+++ b/src/Language/Haskell/Exts/Pretty.hs
@@ -1175,6 +1175,7 @@ specialName UnboxedSingleCon = "(# #)"
 
 ppContext :: Context -> Doc
 ppContext []      = empty
+ppContext [ctxt]  = pretty ctxt <+> text "=>"
 ppContext context = mySep [parenList (map pretty context), text "=>"]
 
 -- hacked for multi-parameter type classes

--- a/tests/examples/CParser.hs.prettyprinter.golden
+++ b/tests/examples/CParser.hs.prettyprinter.golden
@@ -6182,7 +6182,7 @@ instance Pos (Located a) where
  
 {-# INLINE withNodeInfo #-}
  
-withNodeInfo :: (Pos node) => node -> (NodeInfo -> a) -> P a
+withNodeInfo :: Pos node => node -> (NodeInfo -> a) -> P a
 withNodeInfo node mkAttrNode
   = do name <- getNewName
        lastTok <- getSavedToken
@@ -6217,7 +6217,7 @@ instance Pos (CDeclrR) where
 {-# INLINE withAttribute #-}
  
 withAttribute ::
-                (Pos node) => node -> [CAttr] -> (NodeInfo -> CDeclrR) -> P CDeclrR
+                Pos node => node -> [CAttr] -> (NodeInfo -> CDeclrR) -> P CDeclrR
 withAttribute node cattrs mkDeclrNode
   = do name <- getNewName
        let attrs = mkNodeInfo (posOf node) name
@@ -6227,7 +6227,7 @@ withAttribute node cattrs mkDeclrNode
 {-# INLINE withAttributePF #-}
  
 withAttributePF ::
-                  (Pos node) =>
+                  Pos node =>
                   node ->
                     [CAttr] ->
                       (NodeInfo -> CDeclrR -> CDeclrR) -> P (CDeclrR -> CDeclrR)
@@ -6338,10 +6338,10 @@ addTrailingAttrs declspecs new_attrs
                                 node))
         _ -> declspecs `rappend` (liftCAttrs new_attrs)
  
-instance (Pos a) => Pos [a] where
+instance Pos a => Pos [a] where
         posOf (x : _) = posOf x
  
-instance (Pos a) => Pos (Reversed a) where
+instance Pos a => Pos (Reversed a) where
         posOf (Reversed x) = posOf x
  
 emptyDeclr :: CDeclrR

--- a/tests/examples/ClassContext.hs.prettyparser.golden
+++ b/tests/examples/ClassContext.hs.prettyparser.golden
@@ -1,8 +1,1 @@
-Failed to parse output of pretty-printer:
-ParseFailed (SrcLoc "<unknown>.hs" 4 1) "Malformed context: FlexibleContexts is not enabled"
-The pretty-printer output follows.
-
-module Main (main) where
- 
-f :: (Ord (i Int)) => i Int -> i Int
-f = undefined
+Match

--- a/tests/examples/ClassContext.hs.prettyprinter.golden
+++ b/tests/examples/ClassContext.hs.prettyprinter.golden
@@ -1,4 +1,4 @@
 module Main (main) where
  
-f :: (Ord (i Int)) => i Int -> i Int
+f :: Ord (i Int) => i Int -> i Int
 f = undefined

--- a/tests/examples/CxtWhitespace.hs.prettyprinter.golden
+++ b/tests/examples/CxtWhitespace.hs.prettyprinter.golden
@@ -1,5 +1,5 @@
 module Main (main) where
  
-instance (Eq h) => Eq h
+instance Eq h => Eq h
  
 instance (Eq h, Eq h) => Eq h

--- a/tests/examples/Directory.hs.prettyprinter.golden
+++ b/tests/examples/Directory.hs.prettyprinter.golden
@@ -269,7 +269,7 @@ withFileOrSymlinkStatus loc name f
 modificationTime :: Ptr CStat -> IO ClockTime
 modificationTime stat
   = do mtime <- st_mtime stat
-       let realToInteger = round . realToFrac :: (Real a) => a -> Integer
+       let realToInteger = round . realToFrac :: Real a => a -> Integer
        return (TOD (realToInteger (mtime :: CTime)) 0)
  
 isDirectory :: Ptr CStat -> IO Bool

--- a/tests/examples/EqualityConstraints1.hs.prettyprinter.golden
+++ b/tests/examples/EqualityConstraints1.hs.prettyprinter.golden
@@ -1,5 +1,5 @@
 {-# LANGUAGE GADTs #-}
 module Main (main) where
  
-one :: (a ~ Int) => a
+one :: a ~ Int => a
 one = 1

--- a/tests/examples/GenericTree.hs.prettyprinter.golden
+++ b/tests/examples/GenericTree.hs.prettyprinter.golden
@@ -3,6 +3,6 @@ module GenericTree where
 import Data.Typeable
  
 dynRep ::
-         (Typeable a) =>
-         a -> (TypeRep, forall b . (Typeable b) => b -> (Maybe b))
+         Typeable a =>
+         a -> (TypeRep, forall b . Typeable b => b -> (Maybe b))
 dynRep a = (typeOf a, \ _ -> cast a)

--- a/tests/examples/MultiCtxt.hs.prettyprinter.golden
+++ b/tests/examples/MultiCtxt.hs.prettyprinter.golden
@@ -1,5 +1,5 @@
 {-# LANGUAGE RankNTypes #-}
 module MultiCtxt where
  
-multipleCtx :: (Eq a) => ((Show a) => a)
+multipleCtx :: Eq a => (Show a => a)
 multipleCtx = undefined

--- a/tests/examples/ScopedTypeVariables.hs.prettyprinter.golden
+++ b/tests/examples/ScopedTypeVariables.hs.prettyprinter.golden
@@ -7,5 +7,5 @@ test
        return x
 value :: String = "Hello"
  
-forallTest :: forall x . (Eq x) => x -> x
+forallTest :: forall x . Eq x => x -> x
 forallTest x = if x == x then (undefined :: x) else x

--- a/tests/examples/SingleClassAsst.hs.prettyprinter.golden
+++ b/tests/examples/SingleClassAsst.hs.prettyprinter.golden
@@ -1,4 +1,4 @@
 module Test where
  
-foo :: (Eq a) => a -> a
+foo :: Eq a => a -> a
 foo x = x

--- a/tests/examples/SpecializeInstance.hs.prettyprinter.golden
+++ b/tests/examples/SpecializeInstance.hs.prettyprinter.golden
@@ -1,6 +1,6 @@
 module Main (main) where
  
-instance (Sized a) => Sized (Digit a) where
+instance Sized a => Sized (Digit a) where
          
         {-# SPECIALISE instance Sized (Digit (Elem a)) #-}
          

--- a/tests/examples/TypeOperatorsTest.hs.prettyprinter.golden
+++ b/tests/examples/TypeOperatorsTest.hs.prettyprinter.golden
@@ -1,5 +1,5 @@
 {-# LANGUAGE TypeOperators, FlexibleContexts, FlexibleInstances #-}
 module Main (main) where
  
-f :: (ArrowXml (~>)) => a ~> a
+f :: ArrowXml (~>) => a ~> a
 f = undefined


### PR DESCRIPTION
@feuerbach: Nothing technical to review, but a decision should probably be made whether this is a good idea or not.

Ticket #17 hints that we are not treating parenthesis perfectly and things should be restructured. Before that lands in the tree we can improve statistically with our pretty-printing by omitting parentheses on single member class contexts.

Of the test cases that change output, all but three (CxtWhitespace, GenericTree, SingleClassAsst) get a perfect round-trip. CxtWhitespace looks artificial and constructed to test whitespace behaviour of ExactPrinter. The remaining two seem real though, but it's still 9 test cases improving compared to 2 "degrading". 
