### PR TITLE
Make test suite pass on Windows

### DIFF
--- a/haskell-src-exts.cabal
+++ b/haskell-src-exts.cabal
@@ -96,6 +96,7 @@ Test-Suite test
   Build-depends:       base < 5,
                        mtl,
                        containers,
+                       easy-file,
                        filemanip,
                        haskell-src-exts,
                        smallcheck >= 1.0,

--- a/tests/Runner.hs
+++ b/tests/Runner.hs
@@ -8,13 +8,14 @@ import qualified Language.Haskell.Exts as S -- S for "Simple", i.e. not annotate
 import Test.Tasty hiding (defaultMain)
 import Test.Tasty.Golden
 import Test.Tasty.Golden.Manage
-import System.FilePath
+import System.FilePath hiding (normalise)
 import System.FilePath.Find
 import System.IO
 import Control.Monad.Trans
 import Control.Applicative
 import Data.Generics
 import Extensions
+import System.EasyFile(normalise)
 
 main :: IO ()
 main = do
@@ -44,7 +45,7 @@ parserTests sources = testGroup "Parser tests" $ do
     run = do
       ast <-
         parseUTF8FileWithComments
-          (defaultParseMode { parseFilename = file })
+          (defaultParseMode { parseFilename = normalise file })
           file
       writeBinaryFile out $ show ast ++ "\n"
   return $ goldenVsFile (takeBaseName file) golden out run
@@ -63,7 +64,7 @@ exactPrinterTests sources = testGroup "Exact printer tests" $ do
         -- parse
         mbAst =
           parseFileContentsWithComments
-            (defaultParseMode { parseFilename = file })
+            (defaultParseMode { parseFilename = normalise file })
             contents
         -- try to pretty-print; summarize the test result
         result =
@@ -93,7 +94,7 @@ prettyPrinterTests sources = testGroup "Pretty printer tests" $ do
         -- parse
         mbAst =
           S.parseFileContentsWithMode
-            (defaultParseMode { parseFilename = file })
+            (defaultParseMode { parseFilename = normalise file })
             contents
         -- try to pretty-print; summarize the test result
         result =
@@ -118,7 +119,7 @@ prettyParserTests sources = testGroup "Pretty-parser tests" $ do
         parse1Result :: ParseResult S.Module
         parse1Result =
           S.parseFileContentsWithMode
-            (defaultParseMode { parseFilename = file })
+            (defaultParseMode { parseFilename = normalise file })
             contents
 
         prettyResult :: ParseResult String


### PR DESCRIPTION
I'm not certain if easy-file is actually a good dependency to have, but I didn't find anything else on hackage (in my 10 minutes of searching) that would do the proper conversion. It has a few reverse dependencies and files aren't that complicated, so it's probably OK. The other approach is to just hack it out like in 8f04f3366217e3db8f70cfb9839604c833efa1e8, but that seems less clean.
