### PR TITLE
Ignore generated src/.../InternalParser.hs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /dist/
 *.out
+src/Language/Haskell/Exts/InternalParser.hs


### PR DESCRIPTION
I've got some patches coming and this is the first. I was finding it annoying that this generated file kept on showing up in the `git status` output.
