### PR TITLE
Fix the reverse of left and right arrow

### DIFF
--- a/src/Language/Haskell/Exts/InternalLexer.hs
+++ b/src/Language/Haskell/Exts/InternalLexer.hs
@@ -93,10 +93,10 @@ data Token
         | Minus
         | Exclamation
         | Star
-        | LeftArrowTail         -- >-
-        | RightArrowTail        -- -<
-        | LeftDblArrowTail      -- >>-
-        | RightDblArrowTail     -- -<<
+        | LeftArrowTail         -- -<
+        | RightArrowTail        -- >-
+        | LeftDblArrowTail      -- -<<
+        | RightDblArrowTail     -- >>-
 
 -- Template Haskell
         | THExpQuote            -- [| or [e|


### PR DESCRIPTION
Fix the reverse of left and right arrow.  According to http://www.haskell.org/ghc/docs/7.2.1/html/users_guide/syntax-extns.html

As @pjonsson in #174 suggest to seperate the bug fix to a single pull request. 
