### PR TITLE
Descriptive error messages in checkEnabled(OneOf).

### DIFF
--- a/tests/examples/EqualityConstraints2.hs.exactprinter.golden
+++ b/tests/examples/EqualityConstraints2.hs.exactprinter.golden
@@ -1,1 +1,1 @@
-ParseFailed (SrcLoc "tests/examples/EqualityConstraints2.hs" 1 19) "TypeFamilies or GADTs is not enabled"
+ParseFailed (SrcLoc "tests/examples/EqualityConstraints2.hs" 1 19) "At least one of TypeFamilies or GADTs language extensions needs to be enabled. Please add: {-# LANGUAGE TypeFamilies #-} or {-# LANGUAGE GADTs #-} language pragma at the top of your module."

--- a/tests/examples/EqualityConstraints2.hs.parser.golden
+++ b/tests/examples/EqualityConstraints2.hs.parser.golden
@@ -1,1 +1,1 @@
-ParseFailed (SrcLoc "tests/examples/EqualityConstraints2.hs" 1 19) "TypeFamilies or GADTs is not enabled"
+ParseFailed (SrcLoc "tests/examples/EqualityConstraints2.hs" 1 19) "At least one of TypeFamilies or GADTs language extensions needs to be enabled. Please add: {-# LANGUAGE TypeFamilies #-} or {-# LANGUAGE GADTs #-} language pragma at the top of your module."

--- a/tests/examples/EqualityConstraints2.hs.prettyparser.golden
+++ b/tests/examples/EqualityConstraints2.hs.prettyparser.golden
@@ -1,1 +1,1 @@
-ParseFailed (SrcLoc "tests/examples/EqualityConstraints2.hs" 1 19) "TypeFamilies or GADTs is not enabled"
+ParseFailed (SrcLoc "tests/examples/EqualityConstraints2.hs" 1 19) "At least one of TypeFamilies or GADTs language extensions needs to be enabled. Please add: {-# LANGUAGE TypeFamilies #-} or {-# LANGUAGE GADTs #-} language pragma at the top of your module."

--- a/tests/examples/EqualityConstraints2.hs.prettyprinter.golden
+++ b/tests/examples/EqualityConstraints2.hs.prettyprinter.golden
@@ -1,1 +1,1 @@
-ParseFailed (SrcLoc "tests/examples/EqualityConstraints2.hs" 1 19) "TypeFamilies or GADTs is not enabled"
+ParseFailed (SrcLoc "tests/examples/EqualityConstraints2.hs" 1 19) "At least one of TypeFamilies or GADTs language extensions needs to be enabled. Please add: {-# LANGUAGE TypeFamilies #-} or {-# LANGUAGE GADTs #-} language pragma at the top of your module."

--- a/tests/examples/PackageImportsMissing.hs.exactprinter.golden
+++ b/tests/examples/PackageImportsMissing.hs.exactprinter.golden
@@ -1,1 +1,1 @@
-ParseFailed (SrcLoc "tests/examples/PackageImportsMissing.hs" 3 17) "PackageImports is not enabled"
+ParseFailed (SrcLoc "tests/examples/PackageImportsMissing.hs" 3 17) "PackageImports language extension is not enabled. Please add {-# LANGUAGE PackageImports #-} pragma at the top of your module."

--- a/tests/examples/PackageImportsMissing.hs.parser.golden
+++ b/tests/examples/PackageImportsMissing.hs.parser.golden
@@ -1,1 +1,1 @@
-ParseFailed (SrcLoc "tests/examples/PackageImportsMissing.hs" 3 17) "PackageImports is not enabled"
+ParseFailed (SrcLoc "tests/examples/PackageImportsMissing.hs" 3 17) "PackageImports language extension is not enabled. Please add {-# LANGUAGE PackageImports #-} pragma at the top of your module."

--- a/tests/examples/PackageImportsMissing.hs.prettyparser.golden
+++ b/tests/examples/PackageImportsMissing.hs.prettyparser.golden
@@ -1,1 +1,1 @@
-ParseFailed (SrcLoc "tests/examples/PackageImportsMissing.hs" 3 17) "PackageImports is not enabled"
+ParseFailed (SrcLoc "tests/examples/PackageImportsMissing.hs" 3 17) "PackageImports language extension is not enabled. Please add {-# LANGUAGE PackageImports #-} pragma at the top of your module."

--- a/tests/examples/PackageImportsMissing.hs.prettyprinter.golden
+++ b/tests/examples/PackageImportsMissing.hs.prettyprinter.golden
@@ -1,1 +1,1 @@
-ParseFailed (SrcLoc "tests/examples/PackageImportsMissing.hs" 3 17) "PackageImports is not enabled"
+ParseFailed (SrcLoc "tests/examples/PackageImportsMissing.hs" 3 17) "PackageImports language extension is not enabled. Please add {-# LANGUAGE PackageImports #-} pragma at the top of your module."

--- a/tests/examples/RecordWildcardError.hs.exactprinter.golden
+++ b/tests/examples/RecordWildcardError.hs.exactprinter.golden
@@ -1,1 +1,1 @@
-ParseFailed (SrcLoc "tests/examples/RecordWildcardError.hs" 1 12) "RecordWildCards is not enabled"
+ParseFailed (SrcLoc "tests/examples/RecordWildcardError.hs" 1 12) "RecordWildCards language extension is not enabled. Please add {-# LANGUAGE RecordWildCards #-} pragma at the top of your module."

--- a/tests/examples/RecordWildcardError.hs.parser.golden
+++ b/tests/examples/RecordWildcardError.hs.parser.golden
@@ -1,1 +1,1 @@
-ParseFailed (SrcLoc "tests/examples/RecordWildcardError.hs" 1 12) "RecordWildCards is not enabled"
+ParseFailed (SrcLoc "tests/examples/RecordWildcardError.hs" 1 12) "RecordWildCards language extension is not enabled. Please add {-# LANGUAGE RecordWildCards #-} pragma at the top of your module."

--- a/tests/examples/RecordWildcardError.hs.prettyparser.golden
+++ b/tests/examples/RecordWildcardError.hs.prettyparser.golden
@@ -1,1 +1,1 @@
-ParseFailed (SrcLoc "tests/examples/RecordWildcardError.hs" 1 12) "RecordWildCards is not enabled"
+ParseFailed (SrcLoc "tests/examples/RecordWildcardError.hs" 1 12) "RecordWildCards language extension is not enabled. Please add {-# LANGUAGE RecordWildCards #-} pragma at the top of your module."

--- a/tests/examples/RecordWildcardError.hs.prettyprinter.golden
+++ b/tests/examples/RecordWildcardError.hs.prettyprinter.golden
@@ -1,1 +1,1 @@
-ParseFailed (SrcLoc "tests/examples/RecordWildcardError.hs" 1 12) "RecordWildCards is not enabled"
+ParseFailed (SrcLoc "tests/examples/RecordWildcardError.hs" 1 12) "RecordWildCards language extension is not enabled. Please add {-# LANGUAGE RecordWildCards #-} pragma at the top of your module."

--- a/tests/examples/TypeErrorMessage.hs.exactprinter.golden
+++ b/tests/examples/TypeErrorMessage.hs.exactprinter.golden
@@ -1,1 +1,1 @@
-ParseFailed (SrcLoc "tests/examples/TypeErrorMessage.hs" 2 1) "ExplicitForAll or TypeOperators is not enabled"
+ParseFailed (SrcLoc "tests/examples/TypeErrorMessage.hs" 2 1) "At least one of ExplicitForAll or TypeOperators language extensions needs to be enabled. Please add: {-# LANGUAGE ExplicitForAll #-} or {-# LANGUAGE TypeOperators #-} language pragma at the top of your module."

--- a/tests/examples/TypeErrorMessage.hs.parser.golden
+++ b/tests/examples/TypeErrorMessage.hs.parser.golden
@@ -1,1 +1,1 @@
-ParseFailed (SrcLoc "tests/examples/TypeErrorMessage.hs" 2 1) "ExplicitForAll or TypeOperators is not enabled"
+ParseFailed (SrcLoc "tests/examples/TypeErrorMessage.hs" 2 1) "At least one of ExplicitForAll or TypeOperators language extensions needs to be enabled. Please add: {-# LANGUAGE ExplicitForAll #-} or {-# LANGUAGE TypeOperators #-} language pragma at the top of your module."

--- a/tests/examples/TypeErrorMessage.hs.prettyparser.golden
+++ b/tests/examples/TypeErrorMessage.hs.prettyparser.golden
@@ -1,1 +1,1 @@
-ParseFailed (SrcLoc "tests/examples/TypeErrorMessage.hs" 2 1) "ExplicitForAll or TypeOperators is not enabled"
+ParseFailed (SrcLoc "tests/examples/TypeErrorMessage.hs" 2 1) "At least one of ExplicitForAll or TypeOperators language extensions needs to be enabled. Please add: {-# LANGUAGE ExplicitForAll #-} or {-# LANGUAGE TypeOperators #-} language pragma at the top of your module."

--- a/tests/examples/TypeErrorMessage.hs.prettyprinter.golden
+++ b/tests/examples/TypeErrorMessage.hs.prettyprinter.golden
@@ -1,1 +1,1 @@
-ParseFailed (SrcLoc "tests/examples/TypeErrorMessage.hs" 2 1) "ExplicitForAll or TypeOperators is not enabled"
+ParseFailed (SrcLoc "tests/examples/TypeErrorMessage.hs" 2 1) "At least one of ExplicitForAll or TypeOperators language extensions needs to be enabled. Please add: {-# LANGUAGE ExplicitForAll #-} or {-# LANGUAGE TypeOperators #-} language pragma at the top of your module."


### PR DESCRIPTION
Rationale: I have enabled stylish-haskell in my IntelliJ and was greeted with
the existing error message. Initially I thought I had to enable some sort of
stylish-haskell plugin and started googling for a solution.
Only after trying again on a different file, I realised the error
message was complaining about a missing language pragma: the second file
was missing a pragma which I recognised the name of (the first one
I did not know). Only then did I realise that it is not stylish-haskell
that is complaining, but rather it is this code. Feel free to adjust the wording
as long as the spirit of the change is maintained: giving clear error message
as to what happened and what to do to get it to work.
