### PR TITLE
Add non-greedy parsers for the module heads

### DIFF
--- a/src/Language/Haskell/Exts/SrcLoc.hs
+++ b/src/Language/Haskell/Exts/SrcLoc.hs
@@ -113,6 +113,13 @@ combSpanInfo s1 s2 = SrcSpanInfo
     (mergeSrcSpan (srcInfoSpan s1) (srcInfoSpan s2))
     []
 
+-- | Like '(<+?>)', but it also concatenates the 'srcInfoPoints'.
+combSpanMaybe :: SrcSpanInfo -> Maybe SrcSpanInfo -> SrcSpanInfo
+combSpanMaybe s1 Nothing = s1
+combSpanMaybe s1 (Just s2) = SrcSpanInfo
+    (mergeSrcSpan (srcInfoSpan s1) (srcInfoSpan s2))
+    (srcInfoPoints s1 ++ srcInfoPoints s2)
+
 -- | Short name for 'combSpanInfo'
 (<++>) :: SrcSpanInfo -> SrcSpanInfo -> SrcSpanInfo
 (<++>) = combSpanInfo


### PR DESCRIPTION
This is provides the module head parsers from the following pull
request: https://github.com/haskell-suite/haskell-src-exts/pull/90 (issue https://github.com/haskell-suite/haskell-src-exts/issues/46)

And is a continuation of this pull request, which was merged: https://github.com/haskell-suite/haskell-src-exts/pull/163