### PR TITLE
Pretty print unboxed tuples and singletons with spaces

### DIFF
--- a/src/Language/Haskell/Exts/Pretty.hs
+++ b/src/Language/Haskell/Exts/Pretty.hs
@@ -1484,7 +1484,7 @@ parenList = parens . myFsepSimple . punctuate comma
 hashParenList :: [Doc] -> Doc
 hashParenList = hashParens . myFsepSimple . punctuate comma
   where hashParens = parens . hashes
-        hashes = \doc -> char '#' <> doc <> char '#'
+        hashes = \doc -> char '#' <+> doc <+> char '#'
 
 braceList :: [Doc] -> Doc
 braceList = braces . myFsepSimple . punctuate comma

--- a/tests/examples/UnboxedSingleton.hs.prettyprinter.golden
+++ b/tests/examples/UnboxedSingleton.hs.prettyprinter.golden
@@ -1,3 +1,3 @@
 {-# LANGUAGE UnboxedTuples #-}
 module Main (main) where
-foo a = (#a#)
+foo a = (# a #)

--- a/tests/examples/UnboxedTuples.hs.prettyprinter.golden
+++ b/tests/examples/UnboxedTuples.hs.prettyprinter.golden
@@ -1,7 +1,7 @@
 {-# LANGUAGE UnboxedTuples #-}
 module Main (main) where
  
-foo :: (a, b) -> (#b, a#)
+foo :: (a, b) -> (# b, a #)
 foo (a, b)
-  = case (#b, a#) of
-        (#b, a#) -> (#,#) b a
+  = case (# b, a #) of
+        (# b, a #) -> (#,#) b a


### PR DESCRIPTION
Pretty printing and parsing unboxed tuples and singletons works just fine unless we do it together with `MagicHash`. In this case there has to be a space before the closing hash bracket.
