### PR TITLE
Significant improvements when parsing with a long list of extensions

### DIFF
--- a/src/Language/Haskell/Exts/Extension.hs
+++ b/src/Language/Haskell/Exts/Extension.hs
@@ -679,11 +679,11 @@ toExtensionList lang exts' =
         remExts = [ ke | DisableExtension ke <- exts ]
      in impliesExts $ nub $ (langKes ++ addExts) \\ remExts
 -}
-  in go langKes exts'
+  in nub $ go langKes exts'
     where go :: [KnownExtension] -> [Extension] -> [KnownExtension]
           go acc [] = acc
-          go acc (DisableExtension x : exts) = go (nub (delete x acc)) exts
-          go acc (EnableExtension  x : exts) = go (nub (x : acc))      exts
+          go acc (DisableExtension x : exts) = go (filter (/= x) acc) exts
+          go acc (EnableExtension  x : exts) = go (x : acc)           exts
           -- We just throw away UnknownExtensions
           go acc (_ : exts) = go acc exts
 

--- a/src/Language/Haskell/Exts/Extension.hs
+++ b/src/Language/Haskell/Exts/Extension.hs
@@ -679,7 +679,7 @@ toExtensionList lang exts' =
         remExts = [ ke | DisableExtension ke <- exts ]
      in impliesExts $ nub $ (langKes ++ addExts) \\ remExts
 -}
-  in nub $ go langKes exts'
+  in impliesExts $ nub $ go langKes exts'
     where go :: [KnownExtension] -> [Extension] -> [KnownExtension]
           go acc [] = acc
           go acc (DisableExtension x : exts) = go (filter (/= x) acc) exts

--- a/src/Language/Haskell/Exts/Extension.hs
+++ b/src/Language/Haskell/Exts/Extension.hs
@@ -679,7 +679,7 @@ toExtensionList lang exts' =
         remExts = [ ke | DisableExtension ke <- exts ]
      in impliesExts $ nub $ (langKes ++ addExts) \\ remExts
 -}
-  in impliesExts $ go langKes exts'
+  in go langKes exts'
     where go :: [KnownExtension] -> [Extension] -> [KnownExtension]
           go acc [] = acc
           go acc (DisableExtension x : exts) = go (nub (delete x acc)) exts

--- a/src/Language/Haskell/Exts/ParseMonad.hs
+++ b/src/Language/Haskell/Exts/ParseMonad.hs
@@ -175,7 +175,7 @@ data InternalParseMode = IParseMode {
 
 toInternalParseMode :: ParseMode -> InternalParseMode
 toInternalParseMode (ParseMode pf bLang exts _ilang iline _fx) =
-    IParseMode pf (impliesExts $ toExtensionList bLang exts) {-_ilang -} iline {- _fx -}
+    IParseMode pf (toExtensionList bLang exts) {-_ilang -} iline {- _fx -}
 
 
 -- | Monad for parsing

--- a/src/Language/Haskell/Exts/ParseMonad.hs
+++ b/src/Language/Haskell/Exts/ParseMonad.hs
@@ -200,14 +200,14 @@ runParserWithMode :: ParseMode -> P a -> String -> ParseResult a
         srcColumn = 1
     }
 -}
-runParserWithMode mode pm s = fmap fst $ runParserWithModeComments mode pm s
+runParserWithMode mode pm = fmap fst . runParserWithModeComments mode pm
 
 runParser :: P a -> String -> ParseResult a
 runParser = runParserWithMode defaultParseMode
 
 runParserWithModeComments :: ParseMode -> P a -> String -> ParseResult (a, [Comment])
-runParserWithModeComments mode (P m) s =
-  case m s 0 1 start ([],[],[],(False,False),[]) (toInternalParseMode mode) of
+runParserWithModeComments mode = let mode2 = toInternalParseMode mode in \(P m) s ->
+  case m s 0 1 start ([],[],[],(False,False),[]) mode2 of
     Ok (_,_,_,_,cs) a -> ParseOk (a, reverse cs)
     Failed loc msg    -> ParseFailed loc msg
     where start = SrcLoc {


### PR DESCRIPTION
Given the benchmark:

    import Language.Haskell.Exts
    import System.Time.Extra -- from the extra library on Hackage
    import Control.Monad

    main :: IO ()
    main = do
        (d,_) <- duration $ do
            let parser = parseDeclWithMode
                    defaultParseMode{extensions = EnableExtension EmptyDataDecls : [e | e@EnableExtension{} <- knownExtensions]}
            forM_ ([1..10000]) $ \i -> do
                case parser $ "data Foo" ++ show i of
                    ParseOk _ -> return ()
                    _ -> error "done"
        print d

Before these patches this took 45s. After, it takes 0.07s. This benchmark is based on exactly what I do in Hoogle when creating the database, so is _very_ relevant to the real-world usage.

The first change, which reduces it from 45s to 4.5s is to change the O(n^3) algorithm in toExtensionList to an O(n^2) one by dragging the nub out of the accumulator and removing the invariant that each extension is only mentioned once. The next change is to allow parseMode to be partially applied and to calculate the IParseMode in advance, if it has the information to do so. This means that in the tight loop above we only do the O(n^2) algorithms once.

The obvious next-step would be to eliminate the O(n^2) algorithms, using something from containers to give you O(n log n) instead. When parsing whole files, these fixes make little difference, since they are eliminating the startup overhead.