### PR TITLE
Respect fixity declarations inside where/let/class in `applyFixities`.

### DIFF
--- a/src/Language/Haskell/Exts/Annotated/Fixity.hs
+++ b/src/Language/Haskell/Exts/Annotated/Fixity.hs
@@ -159,13 +159,18 @@ getFixities :: Maybe S.ModuleName -> [Decl l] -> [Fixity]
 getFixities mmdl = concatMap (getFixity mmdl)
 
 getFixity :: Maybe S.ModuleName -> Decl l -> [Fixity]
-getFixity mmdl (InfixDecl _ a mp ops) = let p = maybe 9 id mp in map (Fixity (sAssoc a) p) (concatMap g ops)
+getFixity mmdl d = case d of
+    InfixDecl _ a mp ops  -> let p = maybe 9 id mp in map (Fixity (sAssoc a) p) (concatMap g ops)
+    ClassDecl _ _ _ _ cds -> concatMap getClassFixity $ fromMaybe [] cds
+    _ -> []
   where g (VarOp _ x) = f $ sName x
         g (ConOp _ x) = f $ sName x
         f x = case mmdl of
               Nothing -> [            S.UnQual x]
               Just m  -> [S.Qual m x, S.UnQual x]
-getFixity _ _ = []
+
+        getClassFixity (ClsDecl _ cd) = getFixity mmdl cd
+        getClassFixity _ = []
 
 getBindFixities :: Binds l -> [Fixity]
 getBindFixities (BDecls _ ds) = getFixities Nothing ds

--- a/src/Language/Haskell/Exts/Annotated/Fixity.hs
+++ b/src/Language/Haskell/Exts/Annotated/Fixity.hs
@@ -41,6 +41,7 @@ import qualified Language.Haskell.Exts.Syntax as S ( Assoc(..), QOp(..), QName(.
 import Language.Haskell.Exts.Annotated.Simplify ( sQOp, sAssoc, sQName, sModuleHead, sName )
 
 import Control.Monad (when, (<=<), liftM, liftM2, liftM3, liftM4)
+import Data.Maybe (fromMaybe)
 import Data.Traversable (mapM)
 import Prelude hiding (mapM)
 
@@ -142,7 +143,9 @@ instance AppFixity Decl where
         InstDecl  l olp ih idecls         -> liftM (InstDecl  l olp ih)  $ mapM (mapM fix) idecls
         SpliceDecl l spl        -> liftM (SpliceDecl l) $ fix spl
         FunBind l matches       -> liftM (FunBind l) $ mapM fix matches
-        PatBind l p rhs bs      -> liftM3 (PatBind l) (fix p) (fix rhs) (mapM fix bs)
+        PatBind l p rhs bs      ->
+          let extraFix x = applyFixities (fixs++fromMaybe [] (fmap getBindFixities bs)) x
+          in liftM3 (PatBind l) (extraFix p) (extraFix rhs) (mapM extraFix bs)
         AnnPragma l ann'         -> liftM (AnnPragma l) $ fix ann'
         _                       -> return decl
       where fix x = applyFixities fixs x
@@ -164,6 +167,10 @@ getFixity mmdl (InfixDecl _ a mp ops) = let p = maybe 9 id mp in map (Fixity (sA
               Just m  -> [S.Qual m x, S.UnQual x]
 getFixity _ _ = []
 
+getBindFixities :: Binds l -> [Fixity]
+getBindFixities (BDecls _ ds) = getFixities Nothing ds
+getBindFixities _ = []
+
 instance AppFixity Annotation where
     applyFixities fixs ann' = case ann' of
         Ann     l n e   -> liftM (Ann l n) $ fix e
@@ -181,9 +188,9 @@ instance AppFixity InstDecl where
 
 instance AppFixity Match where
     applyFixities fixs match = case match of
-        Match l n ps rhs bs -> liftM3 (Match l n) (mapM fix ps) (fix rhs) (mapM fix bs)
-        InfixMatch l a n ps rhs bs -> liftM4 (flip (InfixMatch l) n) (fix a) (mapM fix ps) (fix rhs) (mapM fix bs)
-      where fix x = applyFixities fixs x
+        Match l n ps rhs bs -> liftM3 (Match l n) (mapM (fix bs) ps) (fix bs rhs) (mapM (fix bs) bs)
+        InfixMatch l a n ps rhs bs -> liftM4 (flip (InfixMatch l) n) (fix bs a) (mapM (fix bs) ps) (fix bs rhs) (mapM (fix bs) bs)
+      where fix bs x = applyFixities (fixs++fromMaybe [] (fmap getBindFixities bs)) x
 
 instance AppFixity Rhs where
     applyFixities fixs rhs = case rhs of
@@ -276,7 +283,9 @@ leafFix fixs e' = case e' of
     App l e1 e2               -> liftM2 (App l) (fix e1) (fix e2)
     NegApp l e                -> liftM (NegApp l) $ fix e
     Lambda l pats e           -> liftM2 (Lambda l) (mapM fix pats) $ fix e
-    Let l bs e                -> liftM2 (Let l) (fix bs) $ fix e
+    Let l bs e                ->
+      let extraFix x = applyFixities (fixs++getBindFixities bs) x
+      in liftM2 (Let l) (extraFix bs) $ extraFix e
     If l e a b                -> liftM3 (If l) (fix e) (fix a) (fix b)
     MultiIf l alts            -> liftM (MultiIf l) (mapM fix alts)
     Case l e alts             -> liftM2 (Case l) (fix e) $ mapM fix alts

--- a/src/Language/Haskell/Exts/Fixity.hs
+++ b/src/Language/Haskell/Exts/Fixity.hs
@@ -195,7 +195,9 @@ instance AppFixity Decl where
         InstDecl loc olp tvs ctxt n ts idecls   -> liftM (InstDecl loc olp tvs ctxt n ts) $ mapM fix idecls
         SpliceDecl loc spl      -> liftM (SpliceDecl loc) $ fix spl
         FunBind matches         -> liftM FunBind $ mapM fix matches
-        PatBind loc p rhs bs    -> liftM3 (PatBind loc) (fix p) (fix rhs) (fix bs)
+        PatBind loc p rhs bs    ->
+          let extraFix x = applyFixities (fixs++getBindFixities bs) x
+          in liftM3 (PatBind loc) (extraFix p) (extraFix rhs) (extraFix bs)
         AnnPragma loc ann       -> liftM (AnnPragma loc) $ fix ann
         _                       -> return decl
       where fix x = applyFixities fixs x
@@ -204,11 +206,18 @@ appFixDecls :: Monad m => [Fixity] -> [Decl] -> m [Decl]
 appFixDecls fixs decls =
     let extraFixs = getFixities decls
      in mapM (applyFixities (fixs++extraFixs)) decls
-  where getFixities = concatMap getFixity
+
+getFixities :: [Decl] -> [Fixity]
+getFixities = concatMap getFixity
+    where
         getFixity (InfixDecl _ a p ops) = map (Fixity a p . g) ops
         getFixity _ = []
         g (VarOp x) = UnQual x
         g (ConOp x) = UnQual x
+
+getBindFixities :: Binds -> [Fixity]
+getBindFixities (BDecls ds) = getFixities ds
+getBindFixities _ = []
 
 instance AppFixity Annotation where
     applyFixities fixs ann = case ann of
@@ -227,7 +236,7 @@ instance AppFixity InstDecl where
 
 instance AppFixity Match where
     applyFixities fixs (Match loc n ps mt rhs bs) = liftM3 (flip (Match loc n) mt) (mapM fix ps) (fix rhs) (fix bs)
-      where fix x = applyFixities fixs x
+      where fix x = applyFixities (fixs++getBindFixities bs) x
 
 instance AppFixity Rhs where
     applyFixities fixs rhs = case rhs of
@@ -320,7 +329,9 @@ leafFix fixs e' = case e' of
     App e1 e2               -> liftM2 App (fix e1) (fix e2)
     NegApp e                -> liftM NegApp $ fix e
     Lambda loc pats e       -> liftM2 (Lambda loc) (mapM fix pats) $ fix e
-    Let bs e                -> liftM2 Let (fix bs) $ fix e
+    Let bs e                ->
+      let extraFix x = applyFixities (fixs++getBindFixities bs) x
+      in liftM2 Let (extraFix bs) $ extraFix e
     If e a b                -> liftM3 If (fix e) (fix a) (fix b)
     MultiIf alts            -> liftM MultiIf (mapM fix alts)
     Case e alts             -> liftM2 Case (fix e) $ mapM fix alts

--- a/src/Language/Haskell/Exts/Fixity.hs
+++ b/src/Language/Haskell/Exts/Fixity.hs
@@ -210,10 +210,14 @@ appFixDecls fixs decls =
 getFixities :: [Decl] -> [Fixity]
 getFixities = concatMap getFixity
     where
-        getFixity (InfixDecl _ a p ops) = map (Fixity a p . g) ops
+        getFixity (InfixDecl _ a p ops)     = map (Fixity a p . g) ops
+        getFixity (ClassDecl _ _ _ _ _ cds) = concatMap getClassFixity cds
         getFixity _ = []
         g (VarOp x) = UnQual x
         g (ConOp x) = UnQual x
+
+        getClassFixity (ClsDecl d) = getFixities [d]
+        getClassFixity _ = []
 
 getBindFixities :: Binds -> [Fixity]
 getBindFixities (BDecls ds) = getFixities ds


### PR DESCRIPTION
Both here,

~~~~{.haskell}
foo = pure 1 <^> pure 2 <^> pure (+) where
  (<^>) = flip (<*>)
  infixr 4 <^>
~~~~

and here,

~~~~{.haskell}
class Foo f where
  (<^>) :: Applicative f => f a -> f (a -> b) -> f b
  infixr 4 <^>

foo = pure 1 <^> pure 2 <^> pure (+)
~~~~

In the body of `foo`, `(<^>)` is right-associative (and indeed GHC parses it as such). This patch modifies `applyFixities` to grab fixities in `Binds` and `ClsDecl`s and take them into account.

---

I'm not sure how to write tests for this, as none of the test groups use `applyFixities`. Should I add another group?