### PR TITLE
GHCJS foreign imports support

### DIFF
--- a/haskell-src-exts.cabal
+++ b/haskell-src-exts.cabal
@@ -1,5 +1,5 @@
 Name:                   haskell-src-exts
-Version:                1.16.0.1
+Version:                1.16.1.0
 License:                BSD3
 License-File:           LICENSE
 Build-Type:             Simple

--- a/src/Language/Haskell/Exts/Annotated/ExactPrint.hs
+++ b/src/Language/Haskell/Exts/Annotated/ExactPrint.hs
@@ -1975,13 +1975,14 @@ instance ExactP Binds where
   exactP (IPBinds l ips) = layoutList (srcInfoPoints l) ips
 
 instance ExactP CallConv where
-  exactP (StdCall   _) = printString "stdcall"
-  exactP (CCall     _) = printString "ccall"
-  exactP (CPlusPlus _) = printString "cplusplus"
-  exactP (DotNet    _) = printString "dotnet"
-  exactP (Jvm       _) = printString "jvm"
-  exactP (Js        _) = printString "js"
-  exactP (CApi      _) = printString "capi"
+  exactP (StdCall    _) = printString "stdcall"
+  exactP (CCall      _) = printString "ccall"
+  exactP (CPlusPlus  _) = printString "cplusplus"
+  exactP (DotNet     _) = printString "dotnet"
+  exactP (Jvm        _) = printString "jvm"
+  exactP (Js         _) = printString "js"
+  exactP (JavaScript _) = printString "javascript"
+  exactP (CApi       _) = printString "capi"
 
 instance ExactP Safety where
   exactP (PlayRisky _) = printString "unsafe"

--- a/src/Language/Haskell/Exts/Annotated/Simplify.hs
+++ b/src/Language/Haskell/Exts/Annotated/Simplify.hs
@@ -474,13 +474,14 @@ sSafety (PlaySafe _ b) = S.PlaySafe b
 sSafety (PlayInterruptible _) = S.PlayInterruptible
 
 sCallConv :: CallConv l -> S.CallConv
-sCallConv (StdCall   _) = S.StdCall
-sCallConv (CCall     _) = S.CCall
-sCallConv (CPlusPlus _) = S.CPlusPlus
-sCallConv (DotNet    _) = S.DotNet
-sCallConv (Jvm       _) = S.Jvm
-sCallConv (Js        _) = S.Js
-sCallConv (CApi      _) = S.CApi
+sCallConv (StdCall    _) = S.StdCall
+sCallConv (CCall      _) = S.CCall
+sCallConv (CPlusPlus  _) = S.CPlusPlus
+sCallConv (DotNet     _) = S.DotNet
+sCallConv (Jvm        _) = S.Jvm
+sCallConv (Js         _) = S.Js
+sCallConv (JavaScript _) = S.JavaScript
+sCallConv (CApi       _) = S.CApi
 
 sModulePragma :: SrcInfo loc => ModulePragma loc -> S.ModulePragma
 sModulePragma pr = case pr of

--- a/src/Language/Haskell/Exts/Annotated/Syntax.hs
+++ b/src/Language/Haskell/Exts/Annotated/Syntax.hs
@@ -93,7 +93,7 @@ module Language.Haskell.Exts.Annotated.Syntax (
     as_name, qualified_name, hiding_name, minus_name, bang_name, dot_name, star_name,
     export_name, safe_name, unsafe_name, interruptible_name, threadsafe_name,
     stdcall_name, ccall_name, cplusplus_name, dotnet_name, jvm_name, js_name,
-    capi_name, forall_name, family_name,
+    javascript_name, capi_name, forall_name, family_name,
     -- ** Type constructors
     unit_tycon_name, fun_tycon_name, list_tycon_name, tuple_tycon_name, unboxed_singleton_tycon_name,
     unit_tycon, fun_tycon, list_tycon, tuple_tycon, unboxed_singleton_tycon,
@@ -781,6 +781,7 @@ data CallConv l
     | DotNet l
     | Jvm l
     | Js l
+    | JavaScript l
     | CApi l
   deriving (Eq,Ord,Show,Typeable,Data,Foldable,Traversable,Functor,Generic)
 
@@ -970,7 +971,8 @@ star_name      l = Symbol l "*"
 
 export_name, safe_name, unsafe_name, interruptible_name, threadsafe_name,
   stdcall_name, ccall_name, cplusplus_name, dotnet_name,
-  jvm_name, js_name, capi_name, forall_name, family_name :: l -> Name l
+  jvm_name, js_name, javascript_name, capi_name, forall_name,
+  family_name :: l -> Name l
 export_name     l = Ident l "export"
 safe_name       l = Ident l "safe"
 unsafe_name     l = Ident l "unsafe"
@@ -982,6 +984,7 @@ cplusplus_name  l = Ident l "cplusplus"
 dotnet_name     l = Ident l "dotnet"
 jvm_name        l = Ident l "jvm"
 js_name         l = Ident l "js"
+javascript_name l = Ident l "javascript"
 capi_name       l = Ident l "capi"
 forall_name     l = Ident l "forall"
 family_name     l = Ident l "family"
@@ -1607,6 +1610,7 @@ instance Annotated CallConv where
     ann (DotNet l) = l
     ann (Jvm l) = l
     ann (Js l) = l
+    ann (JavaScript l) = l
     ann (CApi l) = l
     amap = fmap
 

--- a/src/Language/Haskell/Exts/InternalLexer.hs
+++ b/src/Language/Haskell/Exts/InternalLexer.hs
@@ -200,6 +200,7 @@ data Token
         | KW_DotNet
         | KW_Jvm
         | KW_Js
+        | KW_JavaScript
         | KW_CApi
 
         | EOF
@@ -305,6 +306,7 @@ special_varids = [
  ( "dotnet",        (KW_DotNet,        Just (Any [ForeignFunctionInterface])) ),
  ( "jvm",           (KW_Jvm,           Just (Any [ForeignFunctionInterface])) ),
  ( "js",            (KW_Js,            Just (Any [ForeignFunctionInterface])) ),
+ ( "javascript",    (KW_JavaScript,    Just (Any [ForeignFunctionInterface])) ),
  ( "capi",          (KW_CApi,          Just (Any [CApiFFI])) )
  ]
 
@@ -1379,6 +1381,7 @@ showToken t = case t of
   KW_DotNet     -> "dotnet"
   KW_Jvm        -> "jvm"
   KW_Js         -> "js"
+  KW_JavaScript -> "javascript"
   KW_CApi       -> "capi"
 
   EOF           -> "EOF"

--- a/src/Language/Haskell/Exts/InternalParser.ly
+++ b/src/Language/Haskell/Exts/InternalParser.ly
@@ -1908,7 +1908,7 @@ Miscellaneous (mostly renamings)
 > mparseDecl :: P (Decl SrcSpanInfo)
 > mparseDecl = do
 >     (is, ds, _, _) <- mparseDeclAux
->     when (not $ null is) $ 
+>     when (not $ null is) $
 >        fail $ "Expected single declaration, found import declaration"
 >     checkSingleDecl ds
 

--- a/src/Language/Haskell/Exts/InternalParser.ly
+++ b/src/Language/Haskell/Exts/InternalParser.ly
@@ -210,6 +210,7 @@ FFI
 >       'dotnet'        { Loc $$ KW_DotNet }
 >       'jvm'           { Loc $$ KW_Jvm }
 >       'js'            { Loc $$ KW_Js }          -- 90
+>       'javascript'    { Loc $$ KW_JavaScript }
 >       'capi'          { Loc $$ KW_CApi }
 
 Reserved Ids
@@ -744,13 +745,14 @@ These will only be called on in the presence of a 'foreign' keyword,
 so no need to check for extensions.
 
 > callconv :: { CallConv L }
->          : 'stdcall'                  { StdCall   (nIS $1) }
->          | 'ccall'                    { CCall     (nIS $1) }
->          | 'cplusplus'                { CPlusPlus (nIS $1) }
->          | 'dotnet'                   { DotNet    (nIS $1) }
->          | 'jvm'                      { Jvm       (nIS $1) }
->          | 'js'                       { Js        (nIS $1) }
->          | 'capi'                     { CApi      (nIS $1) }
+>          : 'stdcall'                  { StdCall    (nIS $1) }
+>          | 'ccall'                    { CCall      (nIS $1) }
+>          | 'cplusplus'                { CPlusPlus  (nIS $1) }
+>          | 'dotnet'                   { DotNet     (nIS $1) }
+>          | 'jvm'                      { Jvm        (nIS $1) }
+>          | 'js'                       { Js         (nIS $1) }
+>          | 'javascript'               { JavaScript (nIS $1) }
+>          | 'capi'                     { CApi       (nIS $1) }
 
 
 > safety :: { Maybe (Safety L) }
@@ -1472,6 +1474,7 @@ Hsx Extensions - requires XmlSyntax, but the lexer handles all that.
 >       | 'dotnet'                      { Loc $1 "dotnet" }
 >       | 'jvm'                         { Loc $1 "jvm" }
 >       | 'js'                          { Loc $1 "js" }
+>       | 'javascript'                  { Loc $1 "javascript" }
 >       | 'capi'                        { Loc $1 "capi" }
 >       | 'as'                          { Loc $1 "as" }
 >       | 'by'                          { Loc $1 "by" }
@@ -1769,17 +1772,18 @@ Identifiers and Symbols
 
 > varid_no_safety :: { Name L }
 >       : VARID                 { let Loc l (VarId v) = $1 in Ident (nIS l) v }
->       | 'as'                  { as_name        (nIS $1) }
->       | 'qualified'           { qualified_name (nIS $1) }
->       | 'hiding'              { hiding_name    (nIS $1) }
->       | 'export'              { export_name    (nIS $1) }
->       | 'stdcall'             { stdcall_name   (nIS $1) }
->       | 'ccall'               { ccall_name     (nIS $1) }
->       | 'cplusplus'           { cplusplus_name (nIS $1) }
->       | 'dotnet'              { dotnet_name    (nIS $1) }
->       | 'jvm'                 { jvm_name       (nIS $1) }
->       | 'js'                  { js_name        (nIS $1) }
->       | 'capi'                { capi_name      (nIS $1) }
+>       | 'as'                  { as_name         (nIS $1) }
+>       | 'qualified'           { qualified_name  (nIS $1) }
+>       | 'hiding'              { hiding_name     (nIS $1) }
+>       | 'export'              { export_name     (nIS $1) }
+>       | 'stdcall'             { stdcall_name    (nIS $1) }
+>       | 'ccall'               { ccall_name      (nIS $1) }
+>       | 'cplusplus'           { cplusplus_name  (nIS $1) }
+>       | 'dotnet'              { dotnet_name     (nIS $1) }
+>       | 'jvm'                 { jvm_name        (nIS $1) }
+>       | 'js'                  { js_name         (nIS $1) }
+>       | 'javascript'          { javascript_name (nIS $1) }
+>       | 'capi'                { capi_name       (nIS $1) }
 
 > varid :: { Name L }
 >       : varid_no_safety       { $1 }

--- a/src/Language/Haskell/Exts/Pretty.hs
+++ b/src/Language/Haskell/Exts/Pretty.hs
@@ -679,13 +679,14 @@ instance Pretty Safety where
         pretty PlayInterruptible = text "interruptible"
 
 instance Pretty CallConv where
-        pretty StdCall   = text "stdcall"
-        pretty CCall     = text "ccall"
-        pretty CPlusPlus = text "cplusplus"
-        pretty DotNet    = text "dotnet"
-        pretty Jvm       = text "jvm"
-        pretty Js        = text "js"
-        pretty CApi      = text "capi"
+        pretty StdCall    = text "stdcall"
+        pretty CCall      = text "ccall"
+        pretty CPlusPlus  = text "cplusplus"
+        pretty DotNet     = text "dotnet"
+        pretty Jvm        = text "jvm"
+        pretty Js         = text "js"
+        pretty JavaScript = text "javascript"
+        pretty CApi       = text "capi"
 
 ------------------------- Pragmas ---------------------------------------
 ppWarnDepr :: ([Name], String) -> Doc

--- a/src/Language/Haskell/Exts/Pretty.hs
+++ b/src/Language/Haskell/Exts/Pretty.hs
@@ -289,10 +289,10 @@ instance Pretty Module where
                 myVcat $ map pretty os ++
                     (if m == ModuleName "" then id
                      else \x -> [topLevel (ppModuleHeader m mbWarn mbExports) x])
-                    (map pretty imp ++ 
+                    (map pretty imp ++
                       ppDecls (m /= ModuleName "" ||
-                               not (null imp) || 
-                               not (null os)) 
+                               not (null imp) ||
+                               not (null os))
                               decls)
 
 --------------------------  Module Header ------------------------------
@@ -363,7 +363,7 @@ condBlankline d = (if wantsBlankline d then blankline else id) $ pretty d
 
 ppDecls :: PrettyDeclLike a => Bool -> [a] -> [Doc]
 ppDecls True  ds     = map condBlankline ds
-ppDecls False (d:ds) = pretty d : map condBlankline ds 
+ppDecls False (d:ds) = pretty d : map condBlankline ds
 ppDecls _ _ = []
 --ppDecls = map condBlankline
 
@@ -1128,10 +1128,10 @@ instance Pretty RPat where
         pretty (RPEither r1 r2) = parens . myFsep $
                 [pretty r1, char '|', pretty r2]
         pretty (RPSeq rs) =
-                myFsep $ text "(|" : (punctuate comma . map pretty $ rs) 
+                myFsep $ text "(|" : (punctuate comma . map pretty $ rs)
                            ++ [text "|)"]
         pretty (RPGuard r gs) =
-                myFsep $ text "(|" : pretty r : char '|' : 
+                myFsep $ text "(|" : pretty r : char '|' :
                            (punctuate comma . map pretty $ gs) ++ [text "|)"]
         -- special case that would otherwise be buggy
         pretty (RPCAs n (RPPat (PIrrPat p))) =
@@ -1330,10 +1330,10 @@ instance SrcInfo pos => Pretty (A.Module pos) where
                     (case mbHead of
                         Nothing -> id
                         Just h  -> \x -> [topLevel (pretty h) x])
-                    (map pretty imp ++ 
-                         ppDecls (isJust mbHead || 
-                                  not (null imp) || 
-                                  not (null os)) 
+                    (map pretty imp ++
+                         ppDecls (isJust mbHead ||
+                                  not (null imp) ||
+                                  not (null os))
                            decls)
         pretty (A.XmlPage pos _mn os n attrs mattr cs) =
                 markLine pos $
@@ -1348,7 +1348,7 @@ instance SrcInfo pos => Pretty (A.Module pos) where
                     (case mbHead of
                         Nothing -> id
                         Just h  -> \x -> [topLevel (pretty h) x])
-                    (map pretty imp ++ 
+                    (map pretty imp ++
                       ppDecls (isJust mbHead || not (null imp) || not (null os)) decls ++
                         [let ax = maybe [] (return . pretty) mattr
                           in hcat $
@@ -1818,10 +1818,10 @@ instance SrcInfo loc => Pretty (P.PExp loc) where
         pretty (P.PreOp _ op e)  = pretty op <+> pretty e
         pretty (P.ViewPat _ e p) =
                 myFsep [pretty e, text "->", pretty p]
-        pretty (P.SeqRP _ rs) = 
+        pretty (P.SeqRP _ rs) =
             myFsep $ text "(|" : (punctuate comma . map pretty $ rs) ++ [text "|)"]
         pretty (P.GuardRP _ r gs) =
-                myFsep $ text "(|" : pretty r : char '|' : 
+                myFsep $ text "(|" : pretty r : char '|' :
                            (punctuate comma . map pretty $ gs) ++ [text "|)"]
         pretty (P.EitherRP _ r1 r2) = parens . myFsep $ [pretty r1, char '|', pretty r2]
         pretty (P.CAsRP _ n (P.IrrPat _ e)) =

--- a/src/Language/Haskell/Exts/Syntax.hs
+++ b/src/Language/Haskell/Exts/Syntax.hs
@@ -89,7 +89,7 @@ module Language.Haskell.Exts.Syntax (
     as_name, qualified_name, hiding_name, minus_name, bang_name, dot_name, star_name,
     export_name, safe_name, unsafe_name, interruptible_name, threadsafe_name,
     stdcall_name, ccall_name, cplusplus_name, dotnet_name, jvm_name, js_name,
-    capi_name, forall_name, family_name,
+    javascript_name, capi_name, forall_name, family_name,
     -- ** Type constructors
     unit_tycon_name, fun_tycon_name, list_tycon_name, tuple_tycon_name, unboxed_singleton_tycon_name,
     unit_tycon, fun_tycon, list_tycon, tuple_tycon, unboxed_singleton_tycon,
@@ -619,6 +619,7 @@ data CallConv
     | DotNet
     | Jvm
     | Js
+    | JavaScript
     | CApi
   deriving (Eq,Ord,Show,Typeable,Data,Generic)
 
@@ -805,7 +806,8 @@ star_name      = Symbol "*"
 
 export_name, safe_name, unsafe_name, interruptible_name, threadsafe_name,
   stdcall_name, ccall_name, cplusplus_name, dotnet_name,
-  jvm_name, js_name, capi_name, forall_name, family_name :: Name
+  jvm_name, js_name, javascript_name, capi_name, forall_name,
+  family_name :: Name
 export_name     = Ident "export"
 safe_name       = Ident "safe"
 unsafe_name     = Ident "unsafe"
@@ -817,6 +819,7 @@ cplusplus_name  = Ident "cplusplus"
 dotnet_name     = Ident "dotnet"
 jvm_name        = Ident "jvm"
 js_name         = Ident "js"
+javascript_name = Ident "js"
 capi_name       = Ident "capi"
 forall_name     = Ident "forall"
 family_name     = Ident "family"


### PR DESCRIPTION
I've just grepped for `capi` and blindly added missing `javascript` keyword where other foreign stuff was.  I've built `stylish-haskell` with this modified version of **HSE** and it was able to parse my files containing GHCJS' foreign imports.  ~~I also want to test HLint before merge, but I suspect this also will work just fine.~~

**UPDATE**: **HLint** works fine too.

~~The only one question I have is about language extensions [here](https://github.com/geraldus/haskell-src-exts/commit/0246c4d593fbd96870c3f959431a9fe28137ed0a#diff-04c9388610a38f8c75922a22984c8c3dR309)~~

> ~~luite: Geraldus: the default language is Haskell2010 which includes ForeignFunctionInterface, Haskel98 doesn't~~

~~so I'm confused, is it really needed or I can remove that extension?~~

**UPDATE**: I think it's better to leave `ForeignFunctionInterface` extension.  So, except the `tasty-golden` issue this is ready to be merged.