### PR TITLE
Remove a redundant name from an import

### DIFF
--- a/src/Language/Haskell/Exts/Extension.hs
+++ b/src/Language/Haskell/Exts/Extension.hs
@@ -41,7 +41,7 @@ module Language.Haskell.Exts.Extension (
 
 import Control.Applicative ((<$>), (<|>))
 import Data.Array (Array, accumArray, bounds, Ix(inRange), (!))
-import Data.List (nub, delete)
+import Data.List (nub)
 import Data.Maybe (fromMaybe)
 import Data.Data
 


### PR DESCRIPTION
Fixes a warning. Generally, on the CI servers I run with `-fwarn-unused-binds -fwarn-unused-imports`, which might be a good idea for HSE as well.