### PR TITLE
Make the fields of SrcLoc and SrcSpan strict

### DIFF
--- a/src/Language/Haskell/Exts/SrcLoc.hs
+++ b/src/Language/Haskell/Exts/SrcLoc.hs
@@ -20,9 +20,9 @@ import GHC.Generics (Generic)
 
 -- | A single position in the source.
 data SrcLoc = SrcLoc
-    { srcFilename :: String
-    , srcLine :: Int
-    , srcColumn :: Int
+    { srcFilename :: !String
+    , srcLine :: !Int
+    , srcColumn :: !Int
     }
   deriving (Eq,Ord,Typeable,Data,Generic)
 
@@ -36,11 +36,11 @@ noLoc = SrcLoc "" (-1) (-1)
 
 -- | A portion of the source, spanning one or more lines and zero or more columns.
 data SrcSpan = SrcSpan
-    { srcSpanFilename    :: String
-    , srcSpanStartLine   :: Int
-    , srcSpanStartColumn :: Int
-    , srcSpanEndLine     :: Int
-    , srcSpanEndColumn   :: Int
+    { srcSpanFilename    :: !String
+    , srcSpanStartLine   :: !Int
+    , srcSpanStartColumn :: !Int
+    , srcSpanEndLine     :: !Int
+    , srcSpanEndColumn   :: !Int
     }
   deriving (Eq,Ord,Typeable,Data)
 


### PR DESCRIPTION
(I think) a lot of the allocations when using HSE are caused by SrcSpans and
SrcLocs. By making the fields strict, GHC can unbox them and hence we
save a number of pointers every time a SrcLoc or SrcSpan is allocated.

There is no empirical measurements to justify this change but
a similar change was introduced in GHC and compiler allocations fell by
a non-trivial amount as a result.