### PR TITLE
Update Changelog and bump version to 1.18.3

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+1.18.2 --> 1.18.3
+===================
+
+* JavaScriptFFI to known extensions
 * Remove space when pretty printing `SrcLoc`. (#307)
 * Don't reverse arguments in a context. (#328)
 

--- a/haskell-src-exts.cabal
+++ b/haskell-src-exts.cabal
@@ -1,5 +1,5 @@
 Name:                   haskell-src-exts
-Version:                1.18.2
+Version:                1.18.3
 License:                BSD3
 License-File:           LICENSE
 Build-Type:             Simple


### PR DESCRIPTION
Virtually any tool which uses HSE and is used in a conjunction with GHCJS will benefit from JavaScriptFFI extension
