### PR TITLE
Eta support

### DIFF
--- a/src/Language/Haskell/Exts/ExactPrint.hs
+++ b/src/Language/Haskell/Exts/ExactPrint.hs
@@ -2078,6 +2078,7 @@ instance ExactP CallConv where
   exactP (CPlusPlus  _) = printString "cplusplus"
   exactP (DotNet     _) = printString "dotnet"
   exactP (Jvm        _) = printString "jvm"
+  exactP (Java       _) = printString "java"
   exactP (Js         _) = printString "js"
   exactP (JavaScript _) = printString "javascript"
   exactP (CApi       _) = printString "capi"

--- a/src/Language/Haskell/Exts/InternalLexer.hs
+++ b/src/Language/Haskell/Exts/InternalLexer.hs
@@ -204,6 +204,7 @@ data Token
         | KW_CPlusPlus
         | KW_DotNet
         | KW_Jvm
+        | KW_Java
         | KW_Js
         | KW_JavaScript
         | KW_CApi
@@ -312,6 +313,7 @@ special_varids = [
  ( "cplusplus",     (KW_CPlusPlus,     Just (Any [ForeignFunctionInterface])) ),
  ( "dotnet",        (KW_DotNet,        Just (Any [ForeignFunctionInterface])) ),
  ( "jvm",           (KW_Jvm,           Just (Any [ForeignFunctionInterface])) ),
+ ( "java",          (KW_Java,          Just (Any [ForeignFunctionInterface])) ),
  ( "js",            (KW_Js,            Just (Any [ForeignFunctionInterface])) ),
  ( "javascript",    (KW_JavaScript,    Just (Any [ForeignFunctionInterface])) ),
  ( "capi",          (KW_CApi,          Just (Any [CApiFFI])) )
@@ -1420,6 +1422,7 @@ showToken t = case t of
   KW_CPlusPlus  -> "cplusplus"
   KW_DotNet     -> "dotnet"
   KW_Jvm        -> "jvm"
+  KW_Java       -> "java"
   KW_Js         -> "js"
   KW_JavaScript -> "javascript"
   KW_CApi       -> "capi"

--- a/src/Language/Haskell/Exts/InternalParser.ly
+++ b/src/Language/Haskell/Exts/InternalParser.ly
@@ -860,8 +860,8 @@ so no need to check for extensions.
 >        | {- empty -}                  { Nothing }
 
 > fspec :: { (Maybe String, Name L, Type L, [S]) }
->       : STRING var_no_safety '::' truedtype               { let Loc l (StringTok (s,_)) = $1 in (Just s, $2, $4, [l,$3]) }
->       |        var_no_safety '::' truedtype               { (Nothing, $1, $3, [$2]) }
+>       : STRING var_no_safety '::' truectype               { let Loc l (StringTok (s,_)) = $1 in (Just s, $2, $4, [l,$3]) }
+>       |        var_no_safety '::' truectype               { (Nothing, $1, $3, [$2]) }
 
 -----------------------------------------------------------------------------
 Pragmas

--- a/src/Language/Haskell/Exts/InternalParser.ly
+++ b/src/Language/Haskell/Exts/InternalParser.ly
@@ -214,6 +214,7 @@ FFI
 >       'cplusplus'     { Loc $$ KW_CPlusPlus }
 >       'dotnet'        { Loc $$ KW_DotNet }
 >       'jvm'           { Loc $$ KW_Jvm }
+>       'java'          { Loc $$ KW_Java }
 >       'js'            { Loc $$ KW_Js }          -- 90
 >       'javascript'    { Loc $$ KW_JavaScript }
 >       'capi'          { Loc $$ KW_CApi }
@@ -845,6 +846,7 @@ so no need to check for extensions.
 >          | 'cplusplus'                { CPlusPlus  (nIS $1) }
 >          | 'dotnet'                   { DotNet     (nIS $1) }
 >          | 'jvm'                      { Jvm        (nIS $1) }
+>          | 'java'                     { Java       (nIS $1) }
 >          | 'js'                       { Js         (nIS $1) }
 >          | 'javascript'               { JavaScript (nIS $1) }
 >          | 'capi'                     { CApi       (nIS $1) }

--- a/src/Language/Haskell/Exts/Pretty.hs
+++ b/src/Language/Haskell/Exts/Pretty.hs
@@ -695,6 +695,7 @@ instance  Pretty (CallConv l) where
         pretty CPlusPlus {}  = text "cplusplus"
         pretty DotNet {}     = text "dotnet"
         pretty Jvm {}        = text "jvm"
+        pretty Java {}       = text "java"
         pretty Js {}         = text "js"
         pretty JavaScript {} = text "javascript"
         pretty CApi {}       = text "capi"

--- a/src/Language/Haskell/Exts/Syntax.hs
+++ b/src/Language/Haskell/Exts/Syntax.hs
@@ -833,6 +833,7 @@ data CallConv l
     | CPlusPlus l
     | DotNet l
     | Jvm l
+    | Java l
     | Js l
     | JavaScript l
     | CApi l
@@ -1724,6 +1725,7 @@ instance Annotated CallConv where
     ann (CPlusPlus l) = l
     ann (DotNet l) = l
     ann (Jvm l) = l
+    ann (Java l) = l
     ann (Js l) = l
     ann (JavaScript l) = l
     ann (CApi l) = l


### PR DESCRIPTION
Eta uses the `java` calling convention, so I've added it as a token to facilitate parsing of FFI imports/exports. Moreover, the FFI signatures allow class constraints so I changed the parsing of `fspec` to use `truectype` instead of `truedtype`. These changes do indeed work as was tested by running `hlint` (which depends on this) on Eta programs that were FFI heavy.