### PR TITLE
Fix the test runner on Windows

### DIFF
--- a/tests/Runner.hs
+++ b/tests/Runner.hs
@@ -158,7 +158,7 @@ prettyParserTests sources = testGroup "Pretty-parser tests" $ do
 
 commentsTests :: FilePath -> TestTree  -- {{{
 commentsTests dir = testGroup "Comments tests" $ do
-    let file = dir </> "HaddockComments.hs"
+    let file = dir ++ "/HaddockComments.hs"
         out = file <.> "comments" <.> "out"
         golden = file <.> "comments" <.> "golden"
         run = do


### PR DESCRIPTION
Otherwise the haddockcomments golden file mismatches because of / vs \