### PR TITLE
#331, fix OverloadedLabels starting with _

### DIFF
--- a/src/Language/Haskell/Exts/InternalLexer.hs
+++ b/src/Language/Haskell/Exts/InternalLexer.hs
@@ -755,7 +755,7 @@ lexStdToken = do
                                                   else discard 1 >> return TApp
 
         '#':c:_ | OverloadedLabels `elem` exts
-                   && isLower c              -> do
+                   && isLower c || c == '_' -> do
                                                   discard 1
                                                   [ident] <- lexIdents
                                                   return $ LabelVarId ident

--- a/tests/examples/OverloadedLabels.hs
+++ b/tests/examples/OverloadedLabels.hs
@@ -13,13 +13,13 @@ import GHC.OverloadedLabels
 instance IsLabel "true" Bool where
   fromLabel _ = True
 
-instance IsLabel "false" Bool where
+instance IsLabel "_False1'" Bool where
   fromLabel _ = False
 
 a :: IsLabel "true" t => t
 a = #true
 
-b = #false
+b = #_False1'
 
 c :: Bool
 c = #true

--- a/tests/examples/OverloadedLabels.hs.parser.golden
+++ b/tests/examples/OverloadedLabels.hs.parser.golden
@@ -255,7 +255,7 @@ ParseOk
                 SrcSpan "tests/examples/OverloadedLabels.hs" 16 1 19 0
             , srcInfoPoints =
                 [ SrcSpan "tests/examples/OverloadedLabels.hs" 16 1 16 9
-                , SrcSpan "tests/examples/OverloadedLabels.hs" 16 31 16 36
+                , SrcSpan "tests/examples/OverloadedLabels.hs" 16 34 16 39
                 , SrcSpan "tests/examples/OverloadedLabels.hs" 17 3 17 3
                 , SrcSpan "tests/examples/OverloadedLabels.hs" 19 1 19 0
                 ]
@@ -264,7 +264,7 @@ ParseOk
           (IRule
              SrcSpanInfo
                { srcInfoSpan =
-                   SrcSpan "tests/examples/OverloadedLabels.hs" 16 10 16 30
+                   SrcSpan "tests/examples/OverloadedLabels.hs" 16 10 16 33
                , srcInfoPoints = []
                }
              Nothing
@@ -272,13 +272,13 @@ ParseOk
              (IHApp
                 SrcSpanInfo
                   { srcInfoSpan =
-                      SrcSpan "tests/examples/OverloadedLabels.hs" 16 10 16 30
+                      SrcSpan "tests/examples/OverloadedLabels.hs" 16 10 16 33
                   , srcInfoPoints = []
                   }
                 (IHApp
                    SrcSpanInfo
                      { srcInfoSpan =
-                         SrcSpan "tests/examples/OverloadedLabels.hs" 16 10 16 25
+                         SrcSpan "tests/examples/OverloadedLabels.hs" 16 10 16 28
                      , srcInfoPoints = []
                      }
                    (IHCon
@@ -303,33 +303,33 @@ ParseOk
                    (TyPromoted
                       SrcSpanInfo
                         { srcInfoSpan =
-                            SrcSpan "tests/examples/OverloadedLabels.hs" 16 18 16 25
+                            SrcSpan "tests/examples/OverloadedLabels.hs" 16 18 16 28
                         , srcInfoPoints = []
                         }
                       (PromotedString
                          SrcSpanInfo
                            { srcInfoSpan =
-                               SrcSpan "tests/examples/OverloadedLabels.hs" 16 18 16 25
+                               SrcSpan "tests/examples/OverloadedLabels.hs" 16 18 16 28
                            , srcInfoPoints = []
                            }
-                         "false"
-                         "false")))
+                         "_False1'"
+                         "_False1'")))
                 (TyCon
                    SrcSpanInfo
                      { srcInfoSpan =
-                         SrcSpan "tests/examples/OverloadedLabels.hs" 16 26 16 30
+                         SrcSpan "tests/examples/OverloadedLabels.hs" 16 29 16 33
                      , srcInfoPoints = []
                      }
                    (UnQual
                       SrcSpanInfo
                         { srcInfoSpan =
-                            SrcSpan "tests/examples/OverloadedLabels.hs" 16 26 16 30
+                            SrcSpan "tests/examples/OverloadedLabels.hs" 16 29 16 33
                         , srcInfoPoints = []
                         }
                       (Ident
                          SrcSpanInfo
                            { srcInfoSpan =
-                               SrcSpan "tests/examples/OverloadedLabels.hs" 16 26 16 30
+                               SrcSpan "tests/examples/OverloadedLabels.hs" 16 29 16 33
                            , srcInfoPoints = []
                            }
                          "Bool")))))
@@ -523,7 +523,7 @@ ParseOk
       , PatBind
           SrcSpanInfo
             { srcInfoSpan =
-                SrcSpan "tests/examples/OverloadedLabels.hs" 22 1 22 11
+                SrcSpan "tests/examples/OverloadedLabels.hs" 22 1 22 14
             , srcInfoPoints = []
             }
           (PVar
@@ -542,17 +542,17 @@ ParseOk
           (UnGuardedRhs
              SrcSpanInfo
                { srcInfoSpan =
-                   SrcSpan "tests/examples/OverloadedLabels.hs" 22 3 22 11
+                   SrcSpan "tests/examples/OverloadedLabels.hs" 22 3 22 14
                , srcInfoPoints =
                    [ SrcSpan "tests/examples/OverloadedLabels.hs" 22 3 22 4 ]
                }
              (OverloadedLabel
                 SrcSpanInfo
                   { srcInfoSpan =
-                      SrcSpan "tests/examples/OverloadedLabels.hs" 22 5 22 11
+                      SrcSpan "tests/examples/OverloadedLabels.hs" 22 5 22 14
                   , srcInfoPoints = []
                   }
-                "false"))
+                "_False1'"))
           Nothing
       , TypeSig
           SrcSpanInfo

--- a/tests/examples/OverloadedLabels.hs.prettyprinter.golden
+++ b/tests/examples/OverloadedLabels.hs.prettyprinter.golden
@@ -6,12 +6,12 @@ import GHC.OverloadedLabels
 instance IsLabel "true" Bool where
         fromLabel _ = True
 
-instance IsLabel "false" Bool where
+instance IsLabel "_False1'" Bool where
         fromLabel _ = False
 
 a :: IsLabel "true" t => t
 a = #true
-b = #false
+b = #_False1'
 
 c :: Bool
 c = #true


### PR DESCRIPTION
The GHC label syntax permits `#_foo`, but HSE only permits `#foo`. This pull request fixes that.