### PR TITLE
Adapt to the Semigroup–Monoid Proposal

### DIFF
--- a/haskell-src-exts.cabal
+++ b/haskell-src-exts.cabal
@@ -47,7 +47,9 @@ Library
   Build-Depends:        array >= 0.1, pretty >= 1.0, cpphs >= 1.3,
                         base >= 4.5 && < 5,
                         -- this is needed to access GHC.Generics on GHC 7.4
-                        ghc-prim
+                        ghc-prim,
+                        -- this is needed to access Data.Semigroup on GHCs before 8.0
+                        semigroups
 
   Exposed-modules:      Language.Haskell.Exts,
                         Language.Haskell.Exts.Lexer,

--- a/src/Language/Haskell/Exts/InternalParser.ly
+++ b/src/Language/Haskell/Exts/InternalParser.ly
@@ -1,4 +1,5 @@
 > {
+> {-# LANGUAGE CPP #-}
 > {-# OPTIONS_HADDOCK hide #-}
 > -----------------------------------------------------------------------------
 > -- |
@@ -40,6 +41,9 @@
 > import Control.Monad ( liftM, (<=<), when )
 > import Control.Applicative ( (<$>) )
 > import Data.Maybe
+> #if MIN_VERSION_base(4,11,0)
+> import Prelude hiding ((<>))
+> #endif
 import Debug.Trace (trace)
 
 > }

--- a/src/Language/Haskell/Exts/ParseMonad.hs
+++ b/src/Language/Haskell/Exts/ParseMonad.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_HADDOCK hide #-}
 -----------------------------------------------------------------------------
 -- |
@@ -45,7 +46,10 @@ import Language.Haskell.Exts.Extension -- (Extension, impliesExts, haskell2010)
 import Data.List (intercalate)
 import Control.Applicative
 import Control.Monad (when, liftM, ap)
-import Data.Monoid
+import Data.Monoid hiding ((<>))
+#if MIN_VERSION_base(4,9,0)
+import Data.Semigroup
+#endif
 -- To avoid import warnings for Control.Applicative and Data.Monoid
 import Prelude
 
@@ -98,12 +102,24 @@ instance Monad ParseResult where
   ParseOk x           >>= f = f x
   ParseFailed loc msg >>= _ = ParseFailed loc msg
 
-instance Monoid m => Monoid (ParseResult m) where
+#if MIN_VERSION_base(4,9,0)
+instance Semigroup m => Semigroup (ParseResult m) where
+ ParseOk x <> ParseOk y = ParseOk $ x <> y
+ ParseOk _ <> err       = err
+ err       <> _         = err -- left-biased
+#endif
+
+instance ( Monoid m
+#if MIN_VERSION_base(4,9,0) && !(MIN_VERSION_base(4,11,0))
+         , Semigroup m
+#endif
+         ) => Monoid (ParseResult m) where
   mempty = ParseOk mempty
+#if !(MIN_VERSION_base(4,11,0))
   ParseOk x `mappend` ParseOk y = ParseOk $ x `mappend` y
   ParseOk _ `mappend` err       = err
   err       `mappend` _         = err -- left-biased
-
+#endif
 
 -- internal version
 data ParseStatus a = Ok ParseState a | Failed SrcLoc String

--- a/src/Language/Haskell/Exts/ParseMonad.hs
+++ b/src/Language/Haskell/Exts/ParseMonad.hs
@@ -46,11 +46,9 @@ import Language.Haskell.Exts.Extension -- (Extension, impliesExts, haskell2010)
 import Data.List (intercalate)
 import Control.Applicative
 import Control.Monad (when, liftM, ap)
-import Data.Monoid hiding ((<>))
-#if MIN_VERSION_base(4,9,0)
-import Data.Semigroup
-#endif
--- To avoid import warnings for Control.Applicative and Data.Monoid
+import Data.Monoid (Monoid(..))
+import Data.Semigroup (Semigroup(..))
+-- To avoid import warnings for Control.Applicative, Data.Monoid, and Data.Semigroup
 import Prelude
 
 -- | Class providing function for parsing at many different types.
@@ -102,23 +100,19 @@ instance Monad ParseResult where
   ParseOk x           >>= f = f x
   ParseFailed loc msg >>= _ = ParseFailed loc msg
 
-#if MIN_VERSION_base(4,9,0)
 instance Semigroup m => Semigroup (ParseResult m) where
  ParseOk x <> ParseOk y = ParseOk $ x <> y
  ParseOk _ <> err       = err
  err       <> _         = err -- left-biased
-#endif
 
 instance ( Monoid m
-#if MIN_VERSION_base(4,9,0) && !(MIN_VERSION_base(4,11,0))
+#if !(MIN_VERSION_base(4,11,0))
          , Semigroup m
 #endif
          ) => Monoid (ParseResult m) where
   mempty = ParseOk mempty
 #if !(MIN_VERSION_base(4,11,0))
-  ParseOk x `mappend` ParseOk y = ParseOk $ x `mappend` y
-  ParseOk _ `mappend` err       = err
-  err       `mappend` _         = err -- left-biased
+  mappend = (<>)
 #endif
 
 -- internal version

--- a/src/Language/Haskell/Exts/Pretty.hs
+++ b/src/Language/Haskell/Exts/Pretty.hs
@@ -31,7 +31,11 @@ import qualified Language.Haskell.Exts.ParseSyntax as P
 
 import Language.Haskell.Exts.SrcLoc hiding (loc)
 
-import Prelude hiding (exp)
+import Prelude hiding ( exp
+#if MIN_VERSION_base(4,11,0)
+                      , (<>)
+#endif
+                      )
 import qualified Text.PrettyPrint as P
 import Data.List (intersperse)
 import Data.Maybe (isJust , fromMaybe)


### PR DESCRIPTION
Now that `Semigroup` is a superclass of `Monoid` (and exported by the `Prelude`) in GHC 8.4, some minor changes have to be made to `haskell-src-exts`'s internals to make it compile.
  