### PR TITLE
Add fixites for current base

### DIFF
--- a/src/Language/Haskell/Exts/Fixity.hs
+++ b/src/Language/Haskell/Exts/Fixity.hs
@@ -161,15 +161,17 @@ preludeFixities = concat
 baseFixities :: [Fixity]
 baseFixities = preludeFixities ++ concat
     [infixl_ 9 ["!","//","!:"]
+    ,infixr_ 9 ["`Compose`"]
     ,infixl_ 8 ["`shift`","`rotate`","`shiftL`","`shiftR`","`rotateL`","`rotateR`"]
     ,infixl_ 7 [".&."]
     ,infixl_ 6 ["`xor`"]
+    ,infixr_ 6 ["<>"]
     ,infix_  6 [":+"]
     ,infixl_ 5 [".|."]
-    ,infixr_ 5 ["+:+","<++","<+>"] -- fixity conflict for +++ between ReadP and Arrow
+    ,infixr_ 5 ["+:+","<++","<+>", "<|"] -- fixity conflict for +++ between ReadP and Arrow
     ,infix_  5 ["\\\\"]
-    ,infixl_ 4 ["<**>"]
-    ,infix_  4 ["`elemP`","`notElemP`"]
+    ,infixl_ 4 ["<**>", "<$!>"]
+    ,infix_  4 ["`elemP`","`notElemP`", ":~:", ":~~:"]
     ,infixl_ 3 ["<|>"]
     ,infixr_ 3 ["&&&","***"]
     ,infixr_ 2 ["+++","|||"]


### PR DESCRIPTION
Added fixites found via grepping "infix" in the libraries/base folder of GHC repo (commit 4aa98f4a3cb0c965c4df19af2f1ccc2c5483c3a5), and ignored additional operators found under GHC module hierarchy.

Personally I'm missing `<>`'s fixity which mad `hlint` misfire until told what the fixity is.