### PR TITLE
Add support for parsing TemplateHaskell typed splices.

### DIFF
--- a/src/Language/Haskell/Exts/InternalLexer.hs
+++ b/src/Language/Haskell/Exts/InternalLexer.hs
@@ -108,6 +108,7 @@ data Token
         | THCloseQuote          -- |]
         | THIdEscape (String)   -- dollar x
         | THParenEscape         -- dollar (
+        | THTypedParenEscape    -- dollar dollar (
         | THVarQuote            -- 'x (but without the x)
         | THTyQuote             -- ''T (but without the T)
         | THQuasiQuote (String,String)  -- [$...|...]
@@ -716,6 +717,10 @@ lexStdToken = do
                         discard 2
                         return THCloseQuote
 
+        '$':'$':c:_
+                | c == '(' && TemplateHaskell `elem` exts -> do
+                        discard 3
+                        return THTypedParenEscape
         '$':c:_ | isLower c && TemplateHaskell `elem` exts -> do
                         discard 1
                         id <- lexWhile isIdent
@@ -1353,6 +1358,7 @@ showToken t = case t of
   THCloseQuote      -> "|]"
   THIdEscape s      -> '$':s
   THParenEscape     -> "$("
+  THTypedParenEscape -> "$$("
   THVarQuote        -> "'"
   THTyQuote         -> "''"
   THQuasiQuote (n,q) -> "[$" ++ n ++ "|" ++ q ++ "]"

--- a/src/Language/Haskell/Exts/InternalParser.ly
+++ b/src/Language/Haskell/Exts/InternalParser.ly
@@ -183,6 +183,7 @@ Template Haskell
 
 >       IDSPLICE        { Loc _ (THIdEscape _) }   -- $x
 >       '$('            { Loc $$ THParenEscape } -- 60
+>       '$$('           { Loc $$ THTypedParenEscape } -- 60
 >       '[|'            { Loc $$ THExpQuote }
 >       '[p|'           { Loc $$ THPatQuote }
 >       '[t|'           { Loc $$ THTypQuote }
@@ -662,6 +663,7 @@ CHANGE: Arbitrary top-level expressions are considered implicit splices
 >                  }
 
        | '$(' trueexp ')'  { let l = $1 <^^> $3 <** [$1,$3] in SpliceDecl l $ ParenSplice l $2 }
+       | '$$(' trueexp ')' { let l = $1 <^^> $3 <** [$1,$3] in SpliceDecl l $ ParenSplice l $2 }
 
 These require the ForeignFunctionInterface extension, handled by the
 lexer through the 'foreign' (and 'export') keyword.
@@ -983,6 +985,7 @@ the (# and #) lexemes. Kinds will be handled at the kind rule.
 >       | '(' ctype ')'                 { TyParen ($1 <^^> $3 <** [$1,$3]) $2 }
 >       | '(' ctype '::' kind ')'       { TyKind  ($1 <^^> $5 <** [$1,$3,$5]) $2 $4 }
 >       | '$(' trueexp ')'              { let l = ($1 <^^> $3 <** [$1,$3]) in TySplice l $ ParenSplice l $2 }
+>       | '$$(' trueexp ')'             { let l = ($1 <^^> $3 <** [$1,$3]) in TySplice l $ ParenSplice l $2 }
 >       | IDSPLICE                      { let Loc l (THIdEscape s) = $1 in TySplice (nIS l) $ IdSplice (nIS l) s }
 >       | '_'                           { TyWildCard (nIS $1) Nothing }
 >       | QUASIQUOTE                    { let Loc l (THQuasiQuote (n,q)) = $1 in TyQuasiQuote (nIS l) n q }
@@ -1519,6 +1522,7 @@ thing we need to look at here is the erpats that use no non-standard lexemes.
 Template Haskell - all this is enabled in the lexer.
 >       | IDSPLICE                      { let Loc l (THIdEscape s) = $1 in SpliceExp (nIS l) $ IdSplice (nIS l) s }
 >       | '$(' trueexp ')'              { let l = ($1 <^^> $3 <** [$1,$3]) in SpliceExp l $ ParenSplice l $2 }
+>       | '$$(' trueexp ')'             { let l = ($1 <^^> $3 <** [$1,$3]) in SpliceExp l $ ParenSplice l $2 }
 >       | '[|' trueexp '|]'             { let l = ($1 <^^> $3 <** [$1,$3]) in BracketExp l $ ExpBracket l $2 }
 >       | '[p|' exp0 '|]'               {% do { p <- checkPattern $2;
 >                                               let {l = ($1 <^^> $3 <** [$1,$3]) };


### PR DESCRIPTION
This is really an attempt to fix hlint. See https://github.com/haskell-suite/haskell-src-exts/issues/383

I started out with splices `$$(..)` instead of quotes. If this works out, I'll add typed quotes.

It should be noted that I do not have a great or even decent understanding of this package. This is an attempt to "get it to work", where "get it to work" means that [`hlint`](https://github.com/ndmitchell/hlint), compiled against this library, will not fail to parse typed template haskell splices.