### PR TITLE
Add MonadFail instances to ParseMonad.hs

### DIFF
--- a/haskell-src-exts.cabal
+++ b/haskell-src-exts.cabal
@@ -49,10 +49,12 @@ Library
                         base >= 4.5 && < 5,
                         -- this is needed to access GHC.Generics on GHC 7.4
                         ghc-prim
-  -- this is needed to access Data.Semigroup on GHCs before 8.0
+  -- this is needed to access Data.Semigroup and Control.Monad.Fail on GHCs
+  -- before 8.0
   if !impl(ghc >= 8.0)
     Build-Depends:
-                        semigroups >= 0.18.3
+                        semigroups >= 0.18.3,
+                        fail == 4.9.*
 
   Exposed-modules:      Language.Haskell.Exts,
                         Language.Haskell.Exts.Lexer,

--- a/src/Language/Haskell/Exts/ParseMonad.hs
+++ b/src/Language/Haskell/Exts/ParseMonad.hs
@@ -45,6 +45,7 @@ import Language.Haskell.Exts.Extension -- (Extension, impliesExts, haskell2010)
 import Data.List (intercalate)
 import Control.Applicative
 import Control.Monad (when, liftM, ap)
+import qualified Control.Monad.Fail as Fail
 import Data.Monoid hiding ((<>))
 import Data.Semigroup (Semigroup(..))
 -- To avoid import warnings for Control.Applicative, Data.Monoid, and Data.Semigroup
@@ -95,9 +96,11 @@ instance Applicative ParseResult where
 
 instance Monad ParseResult where
   return = ParseOk
-  fail = ParseFailed noLoc
+  fail = Fail.fail
   ParseOk x           >>= f = f x
   ParseFailed loc msg >>= _ = ParseFailed loc msg
+instance Fail.MonadFail ParseResult where
+  fail = ParseFailed noLoc
 
 instance Semigroup m => Semigroup (ParseResult m) where
  ParseOk x <> ParseOk y = ParseOk $ x <> y
@@ -243,6 +246,9 @@ instance Monad P where
         case m i x y l ch s mode of
             Failed loc msg -> Failed loc msg
             Ok s' a -> runP (k a) i x y l ch s' mode
+    fail   = Fail.fail
+
+instance Fail.MonadFail P where
     fail s = P $ \_r _col _line loc _ _stk _m -> Failed loc s
 
 atSrcLoc :: P a -> SrcLoc -> P a
@@ -348,6 +354,9 @@ instance Monad (Lex r) where
     return a = Lex $ \k -> k a
     Lex v >>= f = Lex $ \k -> v (\a -> runL (f a) k)
     Lex v >> Lex w = Lex $ \k -> v (\_ -> w k)
+    fail   = Fail.fail
+
+instance Fail.MonadFail (Lex r) where
     fail s = Lex $ \_ -> fail s
 
 -- Operations on this monad


### PR DESCRIPTION
This is needed for GHC 8.6.1.