### PR TITLE
Support TypeInType

### DIFF
--- a/src/Language/Haskell/Exts/ExactPrint.hs
+++ b/src/Language/Haskell/Exts/ExactPrint.hs
@@ -1037,42 +1037,6 @@ instance ExactP TyVarBind where
                  [] -> exactPC n
                  _ -> errorEP "ExactP: TyVarBind: UnkindedVar is given wrong number of srcInfoPoints"
 
-instance ExactP Kind where
-  exactP kd' = case kd' of
-    KindStar  _     -> printString "*"
-    KindFn    l k1 k2 ->
-        case srcInfoPoints l of
-         [a] -> do
-            exactP k1
-            printStringAt (pos a) "->"
-            exactPC k2
-         _ -> errorEP "ExactP: Kind: KindFn is given wrong number of srcInfoPoints"
-    KindParen l kd  ->
-        case srcInfoPoints l of
-         [_,b] -> do
-            printString "("
-            exactPC kd
-            printStringAt (pos b) ")"
-         _ -> errorEP "ExactP: Kind: KindParen is given wrong number of srcInfoPoints"
-    KindVar _ n     -> epQName n
-    KindApp _ k1 k2 -> do
-        exactP k1
-        exactPC k2
-    KindTuple l ks ->
-        let o = "("
-            e = ")"
-            pts = srcInfoPoints l
-        in printInterleaved (zip pts (o: replicate (length pts - 2) "," ++ [e])) ks
-    KindList  l k ->
-      case srcInfoPoints l of
-        [_, close] -> do
-          printString "["
-          exactPC k
-          printStringAt (pos close) "]"
-        _ -> errorEP "ExactP: Kind: KindList is given wrong number of srcInfoPoints"
-
-
-
 instance ExactP Type where
   exactP t' = case t' of
     TyForall l mtvs mctxt t -> do
@@ -1089,6 +1053,7 @@ instance ExactP Type where
                      _ -> errorEP "ExactP: Type: TyForall is given too few srcInfoPoints"
         maybeEP exactPC mctxt
         exactPC t
+    TyStar  _ -> printString "*"
     TyFun   l t1 t2 ->
         case srcInfoPoints l of
          [a] -> do

--- a/src/Language/Haskell/Exts/ParseSyntax.hs
+++ b/src/Language/Haskell/Exts/ParseSyntax.hs
@@ -300,6 +300,7 @@ data PType l
         (Maybe [TyVarBind l])
         (Maybe (PContext l))
         (PType l)
+     | TyStar  l                                -- ^ @*@, the type of types
      | TyFun   l (PType l) (PType l)            -- ^ function type
      | TyTuple l Boxed     [PType l]            -- ^ tuple type, possibly boxed
      | TyUnboxedSum l [PType l]                 -- ^ unboxed sum
@@ -322,6 +323,7 @@ data PType l
 instance Annotated PType where
     ann t = case t of
       TyForall l _ _ _              -> l
+      TyStar  l                     -> l
       TyFun   l _ _                 -> l
       TyTuple l _ _                 -> l
       TyUnboxedSum l _              -> l
@@ -341,6 +343,7 @@ instance Annotated PType where
       TyQuasiQuote l _ _            -> l
     amap f t' = case t' of
       TyForall l mtvs mcx t         -> TyForall (f l) mtvs mcx t
+      TyStar  l                     -> TyStar (f l)
       TyFun   l t1 t2               -> TyFun (f l) t1 t2
       TyTuple l b ts                -> TyTuple (f l) b ts
       TyUnboxedSum l ts             -> TyUnboxedSum (f l) ts

--- a/src/Language/Haskell/Exts/ParseUtils.hs
+++ b/src/Language/Haskell/Exts/ParseUtils.hs
@@ -1107,6 +1107,7 @@ checkT t simple = case t of
             checkEnabled ExplicitForAll
             ctxt <- checkContext cs
             check1Type pt (S.TyForall l tvs ctxt)
+    TyStar  l         -> return $ S.TyStar l
     TyFun   l at rt   -> check2Types at rt (S.TyFun l)
     TyTuple l b pts   -> checkTypes pts >>= return . S.TyTuple l b
     TyUnboxedSum l es -> checkTypes es >>= return . S.TyUnboxedSum l
@@ -1177,9 +1178,9 @@ checkTyVar n = do
 -- test for that.
 checkKind :: Kind l -> P ()
 checkKind k = case k of
-        KindVar _ q | constrKind q -> checkEnabledOneOf [ConstraintKinds, DataKinds]
+        S.TyVar _ q | constrKind q -> checkEnabledOneOf [ConstraintKinds, DataKinds]
             where constrKind name = case name of
-                    (UnQual _ (Ident _ n)) -> n == "Constraint"
+                    Ident _ n -> n == "Constraint"
                     _                      -> False
 
         _ -> checkEnabled DataKinds

--- a/src/Language/Haskell/Exts/Pretty.hs
+++ b/src/Language/Haskell/Exts/Pretty.hs
@@ -833,6 +833,7 @@ prec_atype = 2  -- argument of type or data constructor, or of a class
 instance  Pretty (Type l) where
         prettyPrec p (TyForall _ mtvs ctxt htype) = parensIf (p > 0) $
                 myFsep [ppForall mtvs, maybePP pretty ctxt, pretty htype]
+        prettyPrec _ (TyStar _) = text "*"
         prettyPrec p (TyFun _ a b) = parensIf (p > 0) $
                 myFsep [ppBType a, text "->", pretty b]
         prettyPrec _ (TyTuple _ bxd l) =
@@ -893,16 +894,6 @@ ppForall (Just []) = empty
 ppForall (Just vs) =    myFsep (text "forall" : map pretty vs ++ [char '.'])
 
 ---------------------------- Kinds ----------------------------
-
-instance  Pretty (Kind l) where
-        prettyPrec _ KindStar{}      = text "*"
-        prettyPrec n (KindFn _ a b)  = parensIf (n > 0) $ myFsep [prettyPrec 1 a, text "->", pretty b]
-        prettyPrec _ (KindParen _ k) = parens $ pretty k
-        prettyPrec _ (KindVar _ n)   = pretty n
-        prettyPrec _ (KindTuple _ t) = parenList . map pretty $ t
-        prettyPrec _ (KindList _ l)  = brackets .  pretty $ l
-        prettyPrec n (KindApp _ a b) =
-          parensIf (n > 3) $ myFsep [prettyPrec 3 a, prettyPrec 4 b]
 
 ppOptKind :: Maybe (Kind l) -> [Doc]
 ppOptKind Nothing  = []
@@ -1670,6 +1661,7 @@ instance SrcInfo loc => Pretty (P.PAsst loc) where
 instance SrcInfo loc => Pretty (P.PType loc) where
         prettyPrec p (P.TyForall _ mtvs ctxt htype) = parensIf (p > 0) $
                 myFsep [ppForall mtvs, maybePP pretty ctxt, pretty htype]
+        prettyPrec _ (P.TyStar _) = text "*"
         prettyPrec p (P.TyFun _ a b) = parensIf (p > 0) $
                 myFsep [prettyPrec prec_btype a, text "->", pretty b]
         prettyPrec _ (P.TyTuple _ bxd l) =

--- a/tests/examples/DataKinds.hs.parser.golden
+++ b/tests/examples/DataKinds.hs.parser.golden
@@ -118,7 +118,7 @@ ParseOk
                      , srcInfoPoints = []
                      }
                    "a")
-                (KindVar
+                (TyCon
                    SrcSpanInfo
                      { srcInfoSpan = SrcSpan "tests/examples/DataKinds.hs" 5 16 5 20
                      , srcInfoPoints = []
@@ -240,7 +240,7 @@ ParseOk
                      , srcInfoPoints = []
                      }
                    "a")
-                (KindList
+                (TyList
                    SrcSpanInfo
                      { srcInfoSpan = SrcSpan "tests/examples/DataKinds.hs" 8 16 8 21
                      , srcInfoPoints =
@@ -248,7 +248,7 @@ ParseOk
                          , SrcSpan "tests/examples/DataKinds.hs" 8 20 8 21
                          ]
                      }
-                   (KindStar
+                   (TyStar
                       SrcSpanInfo
                         { srcInfoSpan = SrcSpan "tests/examples/DataKinds.hs" 8 18 8 19
                         , srcInfoPoints = []
@@ -381,7 +381,7 @@ ParseOk
                      , srcInfoPoints = []
                      }
                    "a")
-                (KindList
+                (TyList
                    SrcSpanInfo
                      { srcInfoSpan = SrcSpan "tests/examples/DataKinds.hs" 13 16 13 28
                      , srcInfoPoints =
@@ -389,7 +389,7 @@ ParseOk
                          , SrcSpan "tests/examples/DataKinds.hs" 13 27 13 28
                          ]
                      }
-                   (KindTuple
+                   (TyTuple
                       SrcSpanInfo
                         { srcInfoSpan = SrcSpan "tests/examples/DataKinds.hs" 13 17 13 27
                         , srcInfoPoints =
@@ -398,7 +398,8 @@ ParseOk
                             , SrcSpan "tests/examples/DataKinds.hs" 13 26 13 27
                             ]
                         }
-                      [ KindVar
+                      Boxed
+                      [ TyCon
                           SrcSpanInfo
                             { srcInfoSpan = SrcSpan "tests/examples/DataKinds.hs" 13 18 13 21
                             , srcInfoPoints = []
@@ -414,7 +415,7 @@ ParseOk
                                   , srcInfoPoints = []
                                   }
                                 "Baz"))
-                      , KindVar
+                      , TyCon
                           SrcSpanInfo
                             { srcInfoSpan = SrcSpan "tests/examples/DataKinds.hs" 13 23 13 26
                             , srcInfoPoints = []
@@ -471,7 +472,7 @@ ParseOk
                      , srcInfoPoints = []
                      }
                    "a")
-                (KindParen
+                (TyParen
                    SrcSpanInfo
                      { srcInfoSpan = SrcSpan "tests/examples/DataKinds.hs" 15 16 15 21
                      , srcInfoPoints =
@@ -479,7 +480,7 @@ ParseOk
                          , SrcSpan "tests/examples/DataKinds.hs" 15 20 15 21
                          ]
                      }
-                   (KindStar
+                   (TyStar
                       SrcSpanInfo
                         { srcInfoSpan = SrcSpan "tests/examples/DataKinds.hs" 15 18 15 19
                         , srcInfoPoints = []
@@ -524,17 +525,17 @@ ParseOk
                      , srcInfoPoints = []
                      }
                    "a")
-                (KindApp
+                (TyApp
                    SrcSpanInfo
                      { srcInfoSpan = SrcSpan "tests/examples/DataKinds.hs" 18 16 18 27
                      , srcInfoPoints = []
                      }
-                   (KindApp
+                   (TyApp
                       SrcSpanInfo
                         { srcInfoSpan = SrcSpan "tests/examples/DataKinds.hs" 18 16 18 23
                         , srcInfoPoints = []
                         }
-                      (KindVar
+                      (TyCon
                          SrcSpanInfo
                            { srcInfoSpan = SrcSpan "tests/examples/DataKinds.hs" 18 16 18 19
                            , srcInfoPoints = []
@@ -550,38 +551,28 @@ ParseOk
                                  , srcInfoPoints = []
                                  }
                                "App")))
-                      (KindVar
+                      (TyVar
                          SrcSpanInfo
                            { srcInfoSpan = SrcSpan "tests/examples/DataKinds.hs" 18 20 18 23
                            , srcInfoPoints = []
                            }
-                         (UnQual
+                         (Ident
                             SrcSpanInfo
                               { srcInfoSpan = SrcSpan "tests/examples/DataKinds.hs" 18 20 18 23
                               , srcInfoPoints = []
                               }
-                            (Ident
-                               SrcSpanInfo
-                                 { srcInfoSpan = SrcSpan "tests/examples/DataKinds.hs" 18 20 18 23
-                                 , srcInfoPoints = []
-                                 }
-                               "foo"))))
-                   (KindVar
+                            "foo")))
+                   (TyVar
                       SrcSpanInfo
                         { srcInfoSpan = SrcSpan "tests/examples/DataKinds.hs" 18 24 18 27
                         , srcInfoPoints = []
                         }
-                      (UnQual
+                      (Ident
                          SrcSpanInfo
                            { srcInfoSpan = SrcSpan "tests/examples/DataKinds.hs" 18 24 18 27
                            , srcInfoPoints = []
                            }
-                         (Ident
-                            SrcSpanInfo
-                              { srcInfoSpan = SrcSpan "tests/examples/DataKinds.hs" 18 24 18 27
-                              , srcInfoPoints = []
-                              }
-                            "baz"))))))
+                         "baz")))))
           []
           Nothing
       , ClassDecl
@@ -622,7 +613,7 @@ ParseOk
                      , srcInfoPoints = []
                      }
                    "a")
-                (KindParen
+                (TyParen
                    SrcSpanInfo
                      { srcInfoSpan = SrcSpan "tests/examples/DataKinds.hs" 20 16 20 24
                      , srcInfoPoints =
@@ -630,22 +621,17 @@ ParseOk
                          , SrcSpan "tests/examples/DataKinds.hs" 20 23 20 24
                          ]
                      }
-                   (KindVar
+                   (TyVar
                       SrcSpanInfo
                         { srcInfoSpan = SrcSpan "tests/examples/DataKinds.hs" 20 17 20 23
                         , srcInfoPoints = []
                         }
-                      (UnQual
+                      (Ident
                          SrcSpanInfo
                            { srcInfoSpan = SrcSpan "tests/examples/DataKinds.hs" 20 17 20 23
                            , srcInfoPoints = []
                            }
-                         (Ident
-                            SrcSpanInfo
-                              { srcInfoSpan = SrcSpan "tests/examples/DataKinds.hs" 20 17 20 23
-                              , srcInfoPoints = []
-                              }
-                            "parens"))))))
+                         "parens")))))
           []
           Nothing
       , DataDecl
@@ -690,7 +676,7 @@ ParseOk
                      , srcInfoPoints = []
                      }
                    "a")
-                (KindList
+                (TyList
                    SrcSpanInfo
                      { srcInfoSpan = SrcSpan "tests/examples/DataKinds.hs" 22 14 22 17
                      , srcInfoPoints =
@@ -698,7 +684,7 @@ ParseOk
                          , SrcSpan "tests/examples/DataKinds.hs" 22 16 22 17
                          ]
                      }
-                   (KindStar
+                   (TyStar
                       SrcSpanInfo
                         { srcInfoSpan = SrcSpan "tests/examples/DataKinds.hs" 22 15 22 16
                         , srcInfoPoints = []
@@ -968,7 +954,7 @@ ParseOk
                      , srcInfoPoints = []
                      }
                    "a")
-                (KindTuple
+                (TyTuple
                    SrcSpanInfo
                      { srcInfoSpan = SrcSpan "tests/examples/DataKinds.hs" 27 14 27 23
                      , srcInfoPoints =
@@ -977,12 +963,13 @@ ParseOk
                          , SrcSpan "tests/examples/DataKinds.hs" 27 22 27 23
                          ]
                      }
-                   [ KindStar
+                   Boxed
+                   [ TyStar
                        SrcSpanInfo
                          { srcInfoSpan = SrcSpan "tests/examples/DataKinds.hs" 27 15 27 16
                          , srcInfoPoints = []
                          }
-                   , KindVar
+                   , TyCon
                        SrcSpanInfo
                          { srcInfoSpan = SrcSpan "tests/examples/DataKinds.hs" 27 18 27 22
                          , srcInfoPoints = []

--- a/tests/examples/FamilyKindSig.hs.parser.golden
+++ b/tests/examples/FamilyKindSig.hs.parser.golden
@@ -84,18 +84,18 @@ ParseOk
                      , srcInfoPoints = []
                      }
                    "a")
-                (KindFn
+                (TyFun
                    SrcSpanInfo
                      { srcInfoSpan = SrcSpan "tests/examples/FamilyKindSig.hs" 4 31 4 37
                      , srcInfoPoints =
                          [ SrcSpan "tests/examples/FamilyKindSig.hs" 4 33 4 35 ]
                      }
-                   (KindStar
+                   (TyStar
                       SrcSpanInfo
                         { srcInfoSpan = SrcSpan "tests/examples/FamilyKindSig.hs" 4 31 4 32
                         , srcInfoPoints = []
                         })
-                   (KindStar
+                   (TyStar
                       SrcSpanInfo
                         { srcInfoSpan = SrcSpan "tests/examples/FamilyKindSig.hs" 4 36 4 37
                         , srcInfoPoints = []

--- a/tests/examples/InfixTypeMinus.hs.parser.golden
+++ b/tests/examples/InfixTypeMinus.hs.parser.golden
@@ -121,7 +121,7 @@ ParseOk
                      , srcInfoPoints = []
                      }
                    "n")
-                (KindVar
+                (TyCon
                    SrcSpanInfo
                      { srcInfoSpan =
                          SrcSpan "tests/examples/InfixTypeMinus.hs" 5 16 5 19
@@ -427,7 +427,7 @@ ParseOk
                      , srcInfoPoints = []
                      }
                    "n")
-                (KindVar
+                (TyCon
                    SrcSpanInfo
                      { srcInfoSpan =
                          SrcSpan "tests/examples/InfixTypeMinus.hs" 6 16 6 19
@@ -733,7 +733,7 @@ ParseOk
                      , srcInfoPoints = []
                      }
                    "n")
-                (KindVar
+                (TyCon
                    SrcSpanInfo
                      { srcInfoSpan =
                          SrcSpan "tests/examples/InfixTypeMinus.hs" 7 16 7 19
@@ -1039,7 +1039,7 @@ ParseOk
                      , srcInfoPoints = []
                      }
                    "n")
-                (KindVar
+                (TyCon
                    SrcSpanInfo
                      { srcInfoSpan =
                          SrcSpan "tests/examples/InfixTypeMinus.hs" 8 16 8 19

--- a/tests/examples/InjectiveTypeFamilies.hs.parser.golden
+++ b/tests/examples/InjectiveTypeFamilies.hs.parser.golden
@@ -415,25 +415,19 @@ ParseOk
                         , srcInfoPoints = []
                         }
                       "result")
-                   (KindVar
+                   (TyVar
                       SrcSpanInfo
                         { srcInfoSpan =
                             SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 14 34 14 35
                         , srcInfoPoints = []
                         }
-                      (UnQual
+                      (Ident
                          SrcSpanInfo
                            { srcInfoSpan =
                                SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 14 34 14 35
                            , srcInfoPoints = []
                            }
-                         (Ident
-                            SrcSpanInfo
-                              { srcInfoSpan =
-                                  SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 14 34 14 35
-                              , srcInfoPoints = []
-                              }
-                            "k"))))))
+                         "k")))))
           (Just
              (InjectivityInfo
                 SrcSpanInfo
@@ -1022,25 +1016,19 @@ ParseOk
                            , srcInfoPoints = []
                            }
                          "a")
-                      (KindVar
+                      (TyVar
                          SrcSpanInfo
                            { srcInfoSpan =
                                SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 22 21 22 22
                            , srcInfoPoints = []
                            }
-                         (UnQual
+                         (Ident
                             SrcSpanInfo
                               { srcInfoSpan =
                                   SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 22 21 22 22
                               , srcInfoPoints = []
                               }
-                            (Ident
-                               SrcSpanInfo
-                                 { srcInfoSpan =
-                                     SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 22 21 22 22
-                                 , srcInfoPoints = []
-                                 }
-                               "k")))))
+                            "k"))))
                 (UnkindedVar
                    SrcSpanInfo
                      { srcInfoSpan =
@@ -1071,25 +1059,19 @@ ParseOk
                      , srcInfoPoints = []
                      }
                    "c")
-                (KindVar
+                (TyVar
                    SrcSpanInfo
                      { srcInfoSpan =
                          SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 22 32 22 33
                      , srcInfoPoints = []
                      }
-                   (UnQual
+                   (Ident
                       SrcSpanInfo
                         { srcInfoSpan =
                             SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 22 32 22 33
                         , srcInfoPoints = []
                         }
-                      (Ident
-                         SrcSpanInfo
-                           { srcInfoSpan =
-                               SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 22 32 22 33
-                           , srcInfoPoints = []
-                           }
-                         "k")))))
+                      "k"))))
           (Just
              (TyVarSig
                 SrcSpanInfo
@@ -1576,25 +1558,19 @@ ParseOk
                      , srcInfoPoints = []
                      }
                    "b")
-                (KindVar
+                (TyVar
                    SrcSpanInfo
                      { srcInfoSpan =
                          SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 29 23 29 24
                      , srcInfoPoints = []
                      }
-                   (UnQual
+                   (Ident
                       SrcSpanInfo
                         { srcInfoSpan =
                             SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 29 23 29 24
                         , srcInfoPoints = []
                         }
-                      (Ident
-                         SrcSpanInfo
-                           { srcInfoSpan =
-                               SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 29 23 29 24
-                           , srcInfoPoints = []
-                           }
-                         "k")))))
+                      "k"))))
           (Just
              (TyVarSig
                 SrcSpanInfo
@@ -2988,7 +2964,7 @@ ParseOk
                            , srcInfoPoints = []
                            }
                          "a")
-                      (KindStar
+                      (TyStar
                          SrcSpanInfo
                            { srcInfoSpan =
                                SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 53 27 53 28
@@ -3011,7 +2987,7 @@ ParseOk
                         , srcInfoPoints = []
                         }
                       "b")
-                   (KindStar
+                   (TyStar
                       SrcSpanInfo
                         { srcInfoSpan =
                             SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 53 36 53 37
@@ -3034,7 +3010,7 @@ ParseOk
                      , srcInfoPoints = []
                      }
                    "c")
-                (KindStar
+                (TyStar
                    SrcSpanInfo
                      { srcInfoSpan =
                          SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 53 45 53 46
@@ -3519,25 +3495,19 @@ ParseOk
                      , srcInfoPoints = []
                      }
                    "b")
-                (KindVar
+                (TyVar
                    SrcSpanInfo
                      { srcInfoSpan =
                          SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 58 29 58 30
                      , srcInfoPoints = []
                      }
-                   (UnQual
+                   (Ident
                       SrcSpanInfo
                         { srcInfoSpan =
                             SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 58 29 58 30
                         , srcInfoPoints = []
                         }
-                      (Ident
-                         SrcSpanInfo
-                           { srcInfoSpan =
-                               SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 58 29 58 30
-                           , srcInfoPoints = []
-                           }
-                         "k")))))
+                      "k"))))
           (Just
              (TyVarSig
                 SrcSpanInfo
@@ -8793,25 +8763,19 @@ ParseOk
                      , srcInfoPoints = []
                      }
                    "a")
-                (KindVar
+                (TyVar
                    SrcSpanInfo
                      { srcInfoSpan =
                          SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 170 21 170 23
                      , srcInfoPoints = []
                      }
-                   (UnQual
+                   (Ident
                       SrcSpanInfo
                         { srcInfoSpan =
                             SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 170 21 170 23
                         , srcInfoPoints = []
                         }
-                      (Ident
-                         SrcSpanInfo
-                           { srcInfoSpan =
-                               SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 170 21 170 23
-                           , srcInfoPoints = []
-                           }
-                         "k1")))))
+                      "k1"))))
           (Just
              (TyVarSig
                 SrcSpanInfo
@@ -8837,25 +8801,19 @@ ParseOk
                         , srcInfoPoints = []
                         }
                       "r")
-                   (KindVar
+                   (TyVar
                       SrcSpanInfo
                         { srcInfoSpan =
                             SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 170 33 170 35
                         , srcInfoPoints = []
                         }
-                      (UnQual
+                      (Ident
                          SrcSpanInfo
                            { srcInfoSpan =
                                SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 170 33 170 35
                            , srcInfoPoints = []
                            }
-                         (Ident
-                            SrcSpanInfo
-                              { srcInfoSpan =
-                                  SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 170 33 170 35
-                              , srcInfoPoints = []
-                              }
-                            "k2"))))))
+                         "k2")))))
           (Just
              (InjectivityInfo
                 SrcSpanInfo
@@ -9220,7 +9178,7 @@ ParseOk
                      , srcInfoPoints = []
                      }
                    "a")
-                (KindStar
+                (TyStar
                    SrcSpanInfo
                      { srcInfoSpan =
                          SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 176 19 176 20
@@ -9295,13 +9253,13 @@ ParseOk
                      , srcInfoPoints = []
                      }
                    "kproxy")
-                (KindApp
+                (TyApp
                    SrcSpanInfo
                      { srcInfoSpan =
                          SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 177 27 177 35
                      , srcInfoPoints = []
                      }
-                   (KindVar
+                   (TyCon
                       SrcSpanInfo
                         { srcInfoSpan =
                             SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 177 27 177 33
@@ -9320,25 +9278,19 @@ ParseOk
                               , srcInfoPoints = []
                               }
                             "KProxy")))
-                   (KindVar
+                   (TyVar
                       SrcSpanInfo
                         { srcInfoSpan =
                             SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 177 34 177 35
                         , srcInfoPoints = []
                         }
-                      (UnQual
+                      (Ident
                          SrcSpanInfo
                            { srcInfoSpan =
                                SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 177 34 177 35
                            , srcInfoPoints = []
                            }
-                         (Ident
-                            SrcSpanInfo
-                              { srcInfoSpan =
-                                  SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 177 34 177 35
-                              , srcInfoPoints = []
-                              }
-                            "k"))))))
+                         "k")))))
           (Just
              (TyVarSig
                 SrcSpanInfo
@@ -9458,13 +9410,13 @@ ParseOk
                               , srcInfoPoints = []
                               }
                             "KProxy"))))
-                (KindApp
+                (TyApp
                    SrcSpanInfo
                      { srcInfoSpan =
                          SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 178 30 178 41
                      , srcInfoPoints = []
                      }
-                   (KindVar
+                   (TyCon
                       SrcSpanInfo
                         { srcInfoSpan =
                             SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 178 30 178 36
@@ -9483,7 +9435,7 @@ ParseOk
                               , srcInfoPoints = []
                               }
                             "KProxy")))
-                   (KindVar
+                   (TyCon
                       SrcSpanInfo
                         { srcInfoSpan =
                             SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 178 37 178 41
@@ -9594,13 +9546,13 @@ ParseOk
                               , srcInfoPoints = []
                               }
                             "KProxy"))))
-                (KindApp
+                (TyApp
                    SrcSpanInfo
                      { srcInfoSpan =
                          SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 179 30 179 38
                      , srcInfoPoints = []
                      }
-                   (KindVar
+                   (TyCon
                       SrcSpanInfo
                         { srcInfoSpan =
                             SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 179 30 179 36
@@ -9619,7 +9571,7 @@ ParseOk
                               , srcInfoPoints = []
                               }
                             "KProxy")))
-                   (KindStar
+                   (TyStar
                       SrcSpanInfo
                         { srcInfoSpan =
                             SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 179 37 179 38
@@ -9729,13 +9681,13 @@ ParseOk
                                  , srcInfoPoints = []
                                  }
                                "KProxy"))))
-                   (KindApp
+                   (TyApp
                       SrcSpanInfo
                         { srcInfoSpan =
                             SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 181 29 181 37
                         , srcInfoPoints = []
                         }
-                      (KindVar
+                      (TyCon
                          SrcSpanInfo
                            { srcInfoSpan =
                                SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 181 29 181 35
@@ -9754,25 +9706,19 @@ ParseOk
                                  , srcInfoPoints = []
                                  }
                                "KProxy")))
-                      (KindVar
+                      (TyVar
                          SrcSpanInfo
                            { srcInfoSpan =
                                SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 181 36 181 37
                            , srcInfoPoints = []
                            }
-                         (UnQual
+                         (Ident
                             SrcSpanInfo
                               { srcInfoSpan =
                                   SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 181 36 181 37
                               , srcInfoPoints = []
                               }
-                            (Ident
-                               SrcSpanInfo
-                                 { srcInfoSpan =
-                                     SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 181 36 181 37
-                                 , srcInfoPoints = []
-                                 }
-                               "k"))))))
+                            "k")))))
              (TyApp
                 SrcSpanInfo
                   { srcInfoSpan =
@@ -9836,13 +9782,13 @@ ParseOk
                                  , srcInfoPoints = []
                                  }
                                "KProxy"))))
-                   (KindApp
+                   (TyApp
                       SrcSpanInfo
                         { srcInfoSpan =
                             SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 181 57 181 65
                         , srcInfoPoints = []
                         }
-                      (KindVar
+                      (TyCon
                          SrcSpanInfo
                            { srcInfoSpan =
                                SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 181 57 181 63
@@ -9861,25 +9807,19 @@ ParseOk
                                  , srcInfoPoints = []
                                  }
                                "KProxy")))
-                      (KindVar
+                      (TyVar
                          SrcSpanInfo
                            { srcInfoSpan =
                                SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 181 64 181 65
                            , srcInfoPoints = []
                            }
-                         (UnQual
+                         (Ident
                             SrcSpanInfo
                               { srcInfoSpan =
                                   SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 181 64 181 65
                               , srcInfoPoints = []
                               }
-                            (Ident
-                               SrcSpanInfo
-                                 { srcInfoSpan =
-                                     SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 181 64 181 65
-                                 , srcInfoPoints = []
-                                 }
-                               "k")))))))
+                            "k"))))))
       , FunBind
           SrcSpanInfo
             { srcInfoSpan =
@@ -12015,25 +11955,19 @@ ParseOk
                      , srcInfoPoints = []
                      }
                    "a")
-                (KindVar
+                (TyVar
                    SrcSpanInfo
                      { srcInfoSpan =
                          SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 217 22 217 23
                      , srcInfoPoints = []
                      }
-                   (UnQual
+                   (Ident
                       SrcSpanInfo
                         { srcInfoSpan =
                             SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 217 22 217 23
                         , srcInfoPoints = []
                         }
-                      (Ident
-                         SrcSpanInfo
-                           { srcInfoSpan =
-                               SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 217 22 217 23
-                           , srcInfoPoints = []
-                           }
-                         "k")))))
+                      "k"))))
           (Just
              (TyVarSig
                 SrcSpanInfo
@@ -12059,25 +11993,19 @@ ParseOk
                         , srcInfoPoints = []
                         }
                       "result")
-                   (KindVar
+                   (TyVar
                       SrcSpanInfo
                         { srcInfoSpan =
                             SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 217 38 217 39
                         , srcInfoPoints = []
                         }
-                      (UnQual
+                      (Ident
                          SrcSpanInfo
                            { srcInfoSpan =
                                SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 217 38 217 39
                            , srcInfoPoints = []
                            }
-                         (Ident
-                            SrcSpanInfo
-                              { srcInfoSpan =
-                                  SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 217 38 217 39
-                              , srcInfoPoints = []
-                              }
-                            "k"))))))
+                         "k")))))
           (Just
              (InjectivityInfo
                 SrcSpanInfo
@@ -12215,25 +12143,19 @@ ParseOk
                         , srcInfoPoints = []
                         }
                       "a")
-                   (KindVar
+                   (TyVar
                       SrcSpanInfo
                         { srcInfoSpan =
                             SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 222 27 222 28
                         , srcInfoPoints = []
                         }
-                      (UnQual
+                      (Ident
                          SrcSpanInfo
                            { srcInfoSpan =
                                SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 222 27 222 28
                            , srcInfoPoints = []
                            }
-                         (Ident
-                            SrcSpanInfo
-                              { srcInfoSpan =
-                                  SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 222 27 222 28
-                              , srcInfoPoints = []
-                              }
-                            "k")))))
+                         "k"))))
              (UnkindedVar
                 SrcSpanInfo
                   { srcInfoSpan =
@@ -12556,25 +12478,19 @@ ParseOk
                         , srcInfoPoints = []
                         }
                       "a")
-                   (KindVar
+                   (TyVar
                       SrcSpanInfo
                         { srcInfoSpan =
                             SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 227 30 227 31
                         , srcInfoPoints = []
                         }
-                      (UnQual
+                      (Ident
                          SrcSpanInfo
                            { srcInfoSpan =
                                SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 227 30 227 31
                            , srcInfoPoints = []
                            }
-                         (Ident
-                            SrcSpanInfo
-                              { srcInfoSpan =
-                                  SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 227 30 227 31
-                              , srcInfoPoints = []
-                              }
-                            "k")))))
+                         "k"))))
              (UnkindedVar
                 SrcSpanInfo
                   { srcInfoSpan =
@@ -12818,25 +12734,19 @@ ParseOk
                         , srcInfoPoints = []
                         }
                       "a")
-                   (KindVar
+                   (TyVar
                       SrcSpanInfo
                         { srcInfoSpan =
                             SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 232 22 232 23
                         , srcInfoPoints = []
                         }
-                      (UnQual
+                      (Ident
                          SrcSpanInfo
                            { srcInfoSpan =
                                SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 232 22 232 23
                            , srcInfoPoints = []
                            }
-                         (Ident
-                            SrcSpanInfo
-                              { srcInfoSpan =
-                                  SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 232 22 232 23
-                              , srcInfoPoints = []
-                              }
-                            "k")))))
+                         "k"))))
              (KindedVar
                 SrcSpanInfo
                   { srcInfoSpan =
@@ -12854,25 +12764,19 @@ ParseOk
                      , srcInfoPoints = []
                      }
                    "b")
-                (KindVar
+                (TyVar
                    SrcSpanInfo
                      { srcInfoSpan =
                          SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 232 31 232 32
                      , srcInfoPoints = []
                      }
-                   (UnQual
+                   (Ident
                       SrcSpanInfo
                         { srcInfoSpan =
                             SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 232 31 232 32
                         , srcInfoPoints = []
                         }
-                      (Ident
-                         SrcSpanInfo
-                           { srcInfoSpan =
-                               SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 232 31 232 32
-                           , srcInfoPoints = []
-                           }
-                         "k")))))
+                      "k"))))
           (Just
              (TyVarSig
                 SrcSpanInfo
@@ -12898,25 +12802,19 @@ ParseOk
                         , srcInfoPoints = []
                         }
                       "r")
-                   (KindVar
+                   (TyVar
                       SrcSpanInfo
                         { srcInfoSpan =
                             SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 232 42 232 44
                         , srcInfoPoints = []
                         }
-                      (UnQual
+                      (Ident
                          SrcSpanInfo
                            { srcInfoSpan =
                                SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 232 42 232 44
                            , srcInfoPoints = []
                            }
-                         (Ident
-                            SrcSpanInfo
-                              { srcInfoSpan =
-                                  SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 232 42 232 44
-                              , srcInfoPoints = []
-                              }
-                            "k2"))))))
+                         "k2")))))
           (Just
              (InjectivityInfo
                 SrcSpanInfo
@@ -13079,20 +12977,20 @@ ParseOk
                            , srcInfoPoints = []
                            }
                          "repr")
-                      (KindFn
+                      (TyFun
                          SrcSpanInfo
                            { srcInfoSpan =
                                SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 236 26 236 32
                            , srcInfoPoints =
                                [ SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 236 28 236 30 ]
                            }
-                         (KindStar
+                         (TyStar
                             SrcSpanInfo
                               { srcInfoSpan =
                                   SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 236 26 236 27
                               , srcInfoPoints = []
                               })
-                         (KindStar
+                         (TyStar
                             SrcSpanInfo
                               { srcInfoSpan =
                                   SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 236 31 236 32
@@ -13115,7 +13013,7 @@ ParseOk
                         , srcInfoPoints = []
                         }
                       "a")
-                   (KindStar
+                   (TyStar
                       SrcSpanInfo
                         { srcInfoSpan =
                             SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 236 40 236 41
@@ -13138,7 +13036,7 @@ ParseOk
                      , srcInfoPoints = []
                      }
                    "b")
-                (KindStar
+                (TyStar
                    SrcSpanInfo
                      { srcInfoSpan =
                          SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 236 49 236 50
@@ -13169,7 +13067,7 @@ ParseOk
                         , srcInfoPoints = []
                         }
                       "r")
-                   (KindStar
+                   (TyStar
                       SrcSpanInfo
                         { srcInfoSpan =
                             SrcSpan "tests/examples/InjectiveTypeFamilies.hs" 236 60 236 61

--- a/tests/examples/PolyKindSigs.hs.parser.golden
+++ b/tests/examples/PolyKindSigs.hs.parser.golden
@@ -89,18 +89,18 @@ ParseOk
                   }
                 "Foo"))
           (Just
-             (KindFn
+             (TyFun
                 SrcSpanInfo
                   { srcInfoSpan = SrcSpan "tests/examples/PolyKindSigs.hs" 7 13 7 19
                   , srcInfoPoints =
                       [ SrcSpan "tests/examples/PolyKindSigs.hs" 7 15 7 17 ]
                   }
-                (KindStar
+                (TyStar
                    SrcSpanInfo
                      { srcInfoSpan = SrcSpan "tests/examples/PolyKindSigs.hs" 7 13 7 14
                      , srcInfoPoints = []
                      })
-                (KindStar
+                (TyStar
                    SrcSpanInfo
                      { srcInfoSpan = SrcSpan "tests/examples/PolyKindSigs.hs" 7 18 7 19
                      , srcInfoPoints = []

--- a/tests/examples/RCategory.hs.parser.golden
+++ b/tests/examples/RCategory.hs.parser.golden
@@ -286,7 +286,7 @@ ParseOk
                          , srcInfoPoints =
                              [ SrcSpan "tests/examples/RCategory.hs" 15 30 15 32 ]
                          }
-                       (KindVar
+                       (TyCon
                           SrcSpanInfo
                             { srcInfoSpan = SrcSpan "tests/examples/RCategory.hs" 15 33 15 43
                             , srcInfoPoints = []

--- a/tests/examples/RCategory2.hs.parser.golden
+++ b/tests/examples/RCategory2.hs.parser.golden
@@ -170,7 +170,7 @@ ParseOk
                          , srcInfoPoints =
                              [ SrcSpan "tests/examples/RCategory2.hs" 6 30 6 32 ]
                          }
-                       (KindVar
+                       (TyCon
                           SrcSpanInfo
                             { srcInfoSpan = SrcSpan "tests/examples/RCategory2.hs" 6 33 6 43
                             , srcInfoPoints = []

--- a/tests/examples/TypeFunctions.hs.parser.golden
+++ b/tests/examples/TypeFunctions.hs.parser.golden
@@ -126,18 +126,18 @@ ParseOk
                         , srcInfoPoints = []
                         }
                       "f")
-                   (KindFn
+                   (TyFun
                       SrcSpanInfo
                         { srcInfoSpan = SrcSpan "tests/examples/TypeFunctions.hs" 5 23 5 29
                         , srcInfoPoints =
                             [ SrcSpan "tests/examples/TypeFunctions.hs" 5 25 5 27 ]
                         }
-                      (KindStar
+                      (TyStar
                          SrcSpanInfo
                            { srcInfoSpan = SrcSpan "tests/examples/TypeFunctions.hs" 5 23 5 24
                            , srcInfoPoints = []
                            })
-                      (KindStar
+                      (TyStar
                          SrcSpanInfo
                            { srcInfoSpan = SrcSpan "tests/examples/TypeFunctions.hs" 5 28 5 29
                            , srcInfoPoints = []
@@ -160,7 +160,7 @@ ParseOk
                   , srcInfoPoints =
                       [ SrcSpan "tests/examples/TypeFunctions.hs" 5 33 5 35 ]
                   }
-                (KindStar
+                (TyStar
                    SrcSpanInfo
                      { srcInfoSpan = SrcSpan "tests/examples/TypeFunctions.hs" 5 36 5 37
                      , srcInfoPoints = []

--- a/tests/examples/TypeInstances.hs.parser.golden
+++ b/tests/examples/TypeInstances.hs.parser.golden
@@ -111,7 +111,7 @@ ParseOk
                          , srcInfoPoints =
                              [ SrcSpan "tests/examples/TypeInstances.hs" 4 14 4 16 ]
                          }
-                       (KindStar
+                       (TyStar
                           SrcSpanInfo
                             { srcInfoSpan = SrcSpan "tests/examples/TypeInstances.hs" 4 17 4 18
                             , srcInfoPoints = []
@@ -237,7 +237,7 @@ ParseOk
                          , srcInfoPoints =
                              [ SrcSpan "tests/examples/TypeInstances.hs" 7 17 7 19 ]
                          }
-                       (KindStar
+                       (TyStar
                           SrcSpanInfo
                             { srcInfoSpan = SrcSpan "tests/examples/TypeInstances.hs" 7 20 7 21
                             , srcInfoPoints = []

--- a/tests/examples/Vta1.hs.parser.golden
+++ b/tests/examples/Vta1.hs.parser.golden
@@ -3745,17 +3745,17 @@ ParseOk
                      , srcInfoPoints = []
                      }
                    "a")
-                (KindFn
+                (TyFun
                    SrcSpanInfo
                      { srcInfoSpan = SrcSpan "tests/examples/Vta1.hs" 61 18 61 24
                      , srcInfoPoints = [ SrcSpan "tests/examples/Vta1.hs" 61 20 61 22 ]
                      }
-                   (KindStar
+                   (TyStar
                       SrcSpanInfo
                         { srcInfoSpan = SrcSpan "tests/examples/Vta1.hs" 61 18 61 19
                         , srcInfoPoints = []
                         })
-                   (KindStar
+                   (TyStar
                       SrcSpanInfo
                         { srcInfoSpan = SrcSpan "tests/examples/Vta1.hs" 61 23 61 24
                         , srcInfoPoints = []
@@ -3823,22 +3823,17 @@ ParseOk
                      , srcInfoPoints = []
                      }
                    "a")
-                (KindVar
+                (TyVar
                    SrcSpanInfo
                      { srcInfoSpan = SrcSpan "tests/examples/Vta1.hs" 62 18 62 19
                      , srcInfoPoints = []
                      }
-                   (UnQual
+                   (Ident
                       SrcSpanInfo
                         { srcInfoSpan = SrcSpan "tests/examples/Vta1.hs" 62 18 62 19
                         , srcInfoPoints = []
                         }
-                      (Ident
-                         SrcSpanInfo
-                           { srcInfoSpan = SrcSpan "tests/examples/Vta1.hs" 62 18 62 19
-                           , srcInfoPoints = []
-                           }
-                         "k")))))
+                      "k"))))
           [ QualConDecl
               SrcSpanInfo
                 { srcInfoSpan = SrcSpan "tests/examples/Vta1.hs" 62 23 62 24
@@ -3902,38 +3897,33 @@ ParseOk
                      , srcInfoPoints = []
                      }
                    "a")
-                (KindFn
+                (TyFun
                    SrcSpanInfo
                      { srcInfoSpan = SrcSpan "tests/examples/Vta1.hs" 63 18 63 29
                      , srcInfoPoints = [ SrcSpan "tests/examples/Vta1.hs" 63 20 63 22 ]
                      }
-                   (KindStar
+                   (TyStar
                       SrcSpanInfo
                         { srcInfoSpan = SrcSpan "tests/examples/Vta1.hs" 63 18 63 19
                         , srcInfoPoints = []
                         })
-                   (KindFn
+                   (TyFun
                       SrcSpanInfo
                         { srcInfoSpan = SrcSpan "tests/examples/Vta1.hs" 63 23 63 29
                         , srcInfoPoints = [ SrcSpan "tests/examples/Vta1.hs" 63 25 63 27 ]
                         }
-                      (KindVar
+                      (TyVar
                          SrcSpanInfo
                            { srcInfoSpan = SrcSpan "tests/examples/Vta1.hs" 63 23 63 24
                            , srcInfoPoints = []
                            }
-                         (UnQual
+                         (Ident
                             SrcSpanInfo
                               { srcInfoSpan = SrcSpan "tests/examples/Vta1.hs" 63 23 63 24
                               , srcInfoPoints = []
                               }
-                            (Ident
-                               SrcSpanInfo
-                                 { srcInfoSpan = SrcSpan "tests/examples/Vta1.hs" 63 23 63 24
-                                 , srcInfoPoints = []
-                                 }
-                               "k")))
-                      (KindStar
+                            "k"))
+                      (TyStar
                          SrcSpanInfo
                            { srcInfoSpan = SrcSpan "tests/examples/Vta1.hs" 63 28 63 29
                            , srcInfoPoints = []
@@ -5104,17 +5094,17 @@ ParseOk
                          , srcInfoPoints = []
                          }
                        "a")
-                    (KindFn
+                    (TyFun
                        SrcSpanInfo
                          { srcInfoSpan = SrcSpan "tests/examples/Vta1.hs" 91 22 91 28
                          , srcInfoPoints = [ SrcSpan "tests/examples/Vta1.hs" 91 24 91 26 ]
                          }
-                       (KindStar
+                       (TyStar
                           SrcSpanInfo
                             { srcInfoSpan = SrcSpan "tests/examples/Vta1.hs" 91 22 91 23
                             , srcInfoPoints = []
                             })
-                       (KindStar
+                       (TyStar
                           SrcSpanInfo
                             { srcInfoSpan = SrcSpan "tests/examples/Vta1.hs" 91 27 91 28
                             , srcInfoPoints = []

--- a/tests/examples/t412.hs.parser.golden
+++ b/tests/examples/t412.hs.parser.golden
@@ -138,28 +138,23 @@ ParseOk
                      , srcInfoPoints = []
                      }
                    "f")
-                (KindFn
+                (TyFun
                    SrcSpanInfo
                      { srcInfoSpan = SrcSpan "tests/examples/t412.hs" 8 16 8 22
                      , srcInfoPoints = [ SrcSpan "tests/examples/t412.hs" 8 18 8 20 ]
                      }
-                   (KindVar
+                   (TyVar
                       SrcSpanInfo
                         { srcInfoSpan = SrcSpan "tests/examples/t412.hs" 8 16 8 17
                         , srcInfoPoints = []
                         }
-                      (UnQual
+                      (Ident
                          SrcSpanInfo
                            { srcInfoSpan = SrcSpan "tests/examples/t412.hs" 8 16 8 17
                            , srcInfoPoints = []
                            }
-                         (Ident
-                            SrcSpanInfo
-                              { srcInfoSpan = SrcSpan "tests/examples/t412.hs" 8 16 8 17
-                              , srcInfoPoints = []
-                              }
-                            "k")))
-                   (KindStar
+                         "k"))
+                   (TyStar
                       SrcSpanInfo
                         { srcInfoSpan = SrcSpan "tests/examples/t412.hs" 8 21 8 22
                         , srcInfoPoints = []


### PR DESCRIPTION
With `TypeInType` enabled, kinds are simply types. So I've made `type Kind = Type`.

Parsing is trickier. The main problem is that `*` can be either a kind or a type operator, and this makes parsing tricky. To avoid a reduce/reduce conflict, I've parameterized the type-related parsing rules so as to assume that `*` is a type operator in "type context" and is a kind (type) in "kind context". This isn't perfect but AFAICT should not cause backwards compatibility problems.