### PR TITLE
Get this to work with GHC 8.8.

### DIFF
--- a/src/Language/Haskell/Exts/ExactPrint.hs
+++ b/src/Language/Haskell/Exts/ExactPrint.hs
@@ -25,6 +25,7 @@ import Language.Haskell.Exts.SrcLoc
 import Language.Haskell.Exts.Comments
 
 import Control.Monad (when, liftM, ap, unless)
+import qualified Control.Monad.Fail as Fail
 #if __GLASGOW_HASKELL__ < 710
 import Control.Applicative (Applicative(..))
 #endif
@@ -57,6 +58,9 @@ instance Monad EP where
         EP f = k a
         (b, l2, c2, s2) = f l1 c1
     in (b, l2, c2, s1 . s2)
+
+instance Fail.MonadFail EP where
+  fail = error
 
 runEP :: EP () -> [Comment] -> String
 runEP (EP f) cs = let (_,_,_,s) = f (1,1) cs in s ""

--- a/src/Language/Haskell/Exts/ParseMonad.hs
+++ b/src/Language/Haskell/Exts/ParseMonad.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_HADDOCK hide #-}
 -----------------------------------------------------------------------------
 -- |
@@ -96,7 +97,9 @@ instance Applicative ParseResult where
 
 instance Monad ParseResult where
   return = ParseOk
+#if !MIN_VERSION_base(4,13,0)
   fail = Fail.fail
+#endif
   ParseOk x           >>= f = f x
   ParseFailed loc msg >>= _ = ParseFailed loc msg
 instance Fail.MonadFail ParseResult where
@@ -246,7 +249,9 @@ instance Monad P where
         case m i x y l ch s mode of
             Failed loc msg -> Failed loc msg
             Ok s' a -> runP (k a) i x y l ch s' mode
+#if !MIN_VERSION_base(4,13,0)
     fail   = Fail.fail
+#endif
 
 instance Fail.MonadFail P where
     fail s = P $ \_r _col _line loc _ _stk _m -> Failed loc s
@@ -354,7 +359,9 @@ instance Monad (Lex r) where
     return a = Lex $ \k -> k a
     Lex v >>= f = Lex $ \k -> v (\a -> runL (f a) k)
     Lex v >> Lex w = Lex $ \k -> v (\_ -> w k)
+#if !MIN_VERSION_base(4,13,0)
     fail   = Fail.fail
+#endif
 
 instance Fail.MonadFail (Lex r) where
     fail s = Lex $ \_ -> fail s


### PR DESCRIPTION
The issue is the `MonadFail` changes.

I tried to do the minimum for compatibility.  Since `fail` is explicitly called in various places, several `Monad` constraints had to be promoted to `MonadFail`.  This could be considered a breaking change, although the current `MonadFail` is effectively the old `Monad`.

I also note there are various `#if __GLASGOW_HASKELL__ < 710` sprinkled throughout.  I somewhat doubt this package will still build on GHC 7, so those blocks can probably be dropped now.