### PR TITLE
fix unicode identifier parsing

### DIFF
--- a/src/Language/Haskell/Exts/InternalLexer.hs
+++ b/src/Language/Haskell/Exts/InternalLexer.hs
@@ -802,7 +802,7 @@ lexStdToken = do
 
             | isUpper c -> lexConIdOrQual ""
 
-            | isLower c || c == '_' -> do
+            | isLetter c || c == '_' -> do
                     idents <- lexIdents
                     case idents of
                      [ident] -> case lookup ident (reserved_ids ++ special_varids) of


### PR DESCRIPTION
Correctly parse identifier that starts with a letter that is neither upper nor lower case (and should count as the latter); e.g. `猫`.

I'm guessing this needs to be fixed in more places; I'd be happy to look into that sometime later, but I'm not very familiar with the codebase and would appreciate some help. I just found this specific bug when fixing a bug in hoogle.

I also did not add any extra tests; I can also do that later if you'd like.