### PR TITLE
Support StandAloneKindSignatures and visible forall quantification

### DIFF
--- a/src/Language/Haskell/Exts/Extension.hs
+++ b/src/Language/Haskell/Exts/Extension.hs
@@ -560,6 +560,8 @@ data KnownExtension =
 
   | BlockArguments
 
+  | StandaloneKindSignatures
+
   deriving (Show, Read, Eq, Ord, Enum, Bounded, Data, Typeable)
 
 -- | Certain extensions imply other extensions, and this function

--- a/src/Language/Haskell/Exts/ParseSyntax.hs
+++ b/src/Language/Haskell/Exts/ParseSyntax.hs
@@ -301,6 +301,7 @@ instance Annotated PContext where
 data PType l
      = TyForall l
         (Maybe [TyVarBind l])
+        QuantVisibility
         (Maybe (PContext l))
         (PType l)
      | TyStar  l                                -- ^ @*@, the type of types
@@ -326,7 +327,7 @@ data PType l
 
 instance Annotated PType where
     ann t = case t of
-      TyForall l _ _ _              -> l
+      TyForall l _ _ _ _            -> l
       TyStar  l                     -> l
       TyFun   l _ _                 -> l
       TyTuple l _ _                 -> l
@@ -347,7 +348,7 @@ instance Annotated PType where
       TyWildCard  l _               -> l
       TyQuasiQuote l _ _            -> l
     amap f t' = case t' of
-      TyForall l mtvs mcx t         -> TyForall (f l) mtvs mcx t
+      TyForall l mtvs q mcx t       -> TyForall (f l) mtvs q mcx t
       TyStar  l                     -> TyStar (f l)
       TyFun   l t1 t2               -> TyFun (f l) t1 t2
       TyTuple l b ts                -> TyTuple (f l) b ts

--- a/tests/examples/ClassContext.hs.parser.golden
+++ b/tests/examples/ClassContext.hs.parser.golden
@@ -33,6 +33,7 @@ ParseOk
                , srcInfoPoints = []
                }
              Nothing
+             InvisibleQuantification
              (Just
                 (CxSingle
                    SrcSpanInfo

--- a/tests/examples/ConstraintKinds.hs.parser.golden
+++ b/tests/examples/ConstraintKinds.hs.parser.golden
@@ -334,6 +334,7 @@ ParseOk
                , srcInfoPoints = []
                }
              Nothing
+             InvisibleQuantification
              (Just
                 (CxSingle
                    SrcSpanInfo

--- a/tests/examples/ConstraintKinds2.hs.parser.golden
+++ b/tests/examples/ConstraintKinds2.hs.parser.golden
@@ -142,6 +142,7 @@ ParseOk
                    , srcInfoPoints = []
                    }
                  Nothing
+                 InvisibleQuantification
                  (Just
                     (CxSingle
                        SrcSpanInfo

--- a/tests/examples/ConstraintKinds3.hs.parser.golden
+++ b/tests/examples/ConstraintKinds3.hs.parser.golden
@@ -144,6 +144,7 @@ ParseOk
                          , srcInfoPoints = []
                          }
                        Nothing
+                       InvisibleQuantification
                        (Just
                           (CxSingle
                              SrcSpanInfo

--- a/tests/examples/ConstructorAndClassOperators.hs.parser.golden
+++ b/tests/examples/ConstructorAndClassOperators.hs.parser.golden
@@ -66,6 +66,7 @@ ParseOk
                , srcInfoPoints = []
                }
              Nothing
+             InvisibleQuantification
              (Just
                 (CxSingle
                    SrcSpanInfo

--- a/tests/examples/ContextOrdering.hs.parser.golden
+++ b/tests/examples/ContextOrdering.hs.parser.golden
@@ -71,6 +71,7 @@ ParseOk
                , srcInfoPoints = []
                }
              Nothing
+             InvisibleQuantification
              (Just
                 (CxSingle
                    SrcSpanInfo

--- a/tests/examples/DefaultSignatures.hs.parser.golden
+++ b/tests/examples/DefaultSignatures.hs.parser.golden
@@ -184,6 +184,7 @@ ParseOk
                       , srcInfoPoints = []
                       }
                     Nothing
+                    InvisibleQuantification
                     (Just
                        (CxSingle
                           SrcSpanInfo

--- a/tests/examples/DerivingVia.hs.parser.golden
+++ b/tests/examples/DerivingVia.hs.parser.golden
@@ -795,6 +795,7 @@ ParseOk
                          }
                        "xx")
                 ])
+             InvisibleQuantification
              Nothing
              (TyFun
                 SrcSpanInfo
@@ -2283,6 +2284,7 @@ ParseOk
                    , srcInfoPoints = []
                    }
                  Nothing
+                 InvisibleQuantification
                  (Just
                     (CxSingle
                        SrcSpanInfo
@@ -2425,6 +2427,7 @@ ParseOk
                           , srcInfoPoints = []
                           }
                         Nothing
+                        InvisibleQuantification
                         (Just
                            (CxSingle
                               SrcSpanInfo
@@ -2538,6 +2541,7 @@ ParseOk
                , srcInfoPoints = []
                }
              Nothing
+             InvisibleQuantification
              (Just
                 (CxSingle
                    SrcSpanInfo
@@ -2583,6 +2587,7 @@ ParseOk
                         , srcInfoPoints = []
                         }
                       Nothing
+                      InvisibleQuantification
                       (Just
                          (CxSingle
                             SrcSpanInfo
@@ -3942,6 +3947,7 @@ ParseOk
                                    }
                                  "m")
                           ])
+                       InvisibleQuantification
                        Nothing
                        (TyInfix
                           SrcSpanInfo
@@ -5437,6 +5443,7 @@ ParseOk
                          , srcInfoPoints = []
                          }
                        Nothing
+                       InvisibleQuantification
                        (Just
                           (CxSingle
                              SrcSpanInfo
@@ -5801,6 +5808,7 @@ ParseOk
                          , srcInfoPoints = []
                          }
                        Nothing
+                       InvisibleQuantification
                        (Just
                           (CxSingle
                              SrcSpanInfo
@@ -6406,6 +6414,7 @@ ParseOk
                          , srcInfoPoints = []
                          }
                        Nothing
+                       InvisibleQuantification
                        (Just
                           (CxSingle
                              SrcSpanInfo
@@ -7011,6 +7020,7 @@ ParseOk
                          , srcInfoPoints = []
                          }
                        Nothing
+                       InvisibleQuantification
                        (Just
                           (CxSingle
                              SrcSpanInfo
@@ -8201,6 +8211,7 @@ ParseOk
                                    }
                                  "m")
                           ])
+                       InvisibleQuantification
                        (Just
                           (CxSingle
                              SrcSpanInfo
@@ -8922,6 +8933,7 @@ ParseOk
                                    }
                                  "m'")
                           ])
+                       InvisibleQuantification
                        (Just
                           (CxSingle
                              SrcSpanInfo
@@ -25754,6 +25766,7 @@ ParseOk
                          , srcInfoPoints = []
                          }
                        Nothing
+                       InvisibleQuantification
                        (Just
                           (CxSingle
                              SrcSpanInfo
@@ -25875,6 +25888,7 @@ ParseOk
                          , srcInfoPoints = []
                          }
                        Nothing
+                       InvisibleQuantification
                        (Just
                           (CxSingle
                              SrcSpanInfo
@@ -26161,6 +26175,7 @@ ParseOk
                          , srcInfoPoints = []
                          }
                        Nothing
+                       InvisibleQuantification
                        (Just
                           (CxSingle
                              SrcSpanInfo
@@ -29455,6 +29470,7 @@ ParseOk
                          , srcInfoPoints = []
                          }
                        Nothing
+                       InvisibleQuantification
                        (Just
                           (CxSingle
                              SrcSpanInfo
@@ -29680,6 +29696,7 @@ ParseOk
                          , srcInfoPoints = []
                          }
                        Nothing
+                       InvisibleQuantification
                        (Just
                           (CxSingle
                              SrcSpanInfo
@@ -29905,6 +29922,7 @@ ParseOk
                          , srcInfoPoints = []
                          }
                        Nothing
+                       InvisibleQuantification
                        (Just
                           (CxSingle
                              SrcSpanInfo

--- a/tests/examples/DerivingVia2.hs.parser.golden
+++ b/tests/examples/DerivingVia2.hs.parser.golden
@@ -1819,6 +1819,7 @@ ParseOk
                                   }
                                 "a")
                          ])
+                      InvisibleQuantification
                       Nothing
                       (TyApp
                          SrcSpanInfo
@@ -2185,6 +2186,7 @@ ParseOk
                                   }
                                 "a")
                          ])
+                      InvisibleQuantification
                       Nothing
                       (TyApp
                          SrcSpanInfo

--- a/tests/examples/Directory.hs.parser.golden
+++ b/tests/examples/Directory.hs.parser.golden
@@ -25148,6 +25148,7 @@ ParseOk
                                           , srcInfoPoints = []
                                           }
                                         Nothing
+                                        InvisibleQuantification
                                         (Just
                                            (CxSingle
                                               SrcSpanInfo

--- a/tests/examples/EmptyContext.hs.parser.golden
+++ b/tests/examples/EmptyContext.hs.parser.golden
@@ -32,6 +32,7 @@ ParseOk
                , srcInfoPoints = []
                }
              Nothing
+             InvisibleQuantification
              (Just
                 (CxEmpty
                    SrcSpanInfo

--- a/tests/examples/EqualityConstraints1.hs.parser.golden
+++ b/tests/examples/EqualityConstraints1.hs.parser.golden
@@ -55,6 +55,7 @@ ParseOk
                , srcInfoPoints = []
                }
              Nothing
+             InvisibleQuantification
              (Just
                 (CxSingle
                    SrcSpanInfo

--- a/tests/examples/Fixity3.hs.parser.golden
+++ b/tests/examples/Fixity3.hs.parser.golden
@@ -82,6 +82,7 @@ ParseOk
                          , srcInfoPoints = []
                          }
                        Nothing
+                       InvisibleQuantification
                        (Just
                           (CxSingle
                              SrcSpanInfo

--- a/tests/examples/FlexibleContextsWithoutVars.hs.parser.golden
+++ b/tests/examples/FlexibleContextsWithoutVars.hs.parser.golden
@@ -55,6 +55,7 @@ ParseOk
                , srcInfoPoints = []
                }
              Nothing
+             InvisibleQuantification
              (Just
                 (CxSingle
                    SrcSpanInfo

--- a/tests/examples/GenericTree.hs.parser.golden
+++ b/tests/examples/GenericTree.hs.parser.golden
@@ -87,6 +87,7 @@ ParseOk
                , srcInfoPoints = []
                }
              Nothing
+             InvisibleQuantification
              (Just
                 (CxSingle
                    SrcSpanInfo
@@ -210,6 +211,7 @@ ParseOk
                                    }
                                  "b")
                           ])
+                       InvisibleQuantification
                        (Just
                           (CxSingle
                              SrcSpanInfo

--- a/tests/examples/InfixTypeMinus.hs.parser.golden
+++ b/tests/examples/InfixTypeMinus.hs.parser.golden
@@ -165,6 +165,7 @@ ParseOk
                    , srcInfoPoints = []
                    }
                  Nothing
+                 InvisibleQuantification
                  (Just
                     (CxSingle
                        SrcSpanInfo
@@ -481,6 +482,7 @@ ParseOk
                    , srcInfoPoints = []
                    }
                  Nothing
+                 InvisibleQuantification
                  (Just
                     (CxSingle
                        SrcSpanInfo
@@ -797,6 +799,7 @@ ParseOk
                    , srcInfoPoints = []
                    }
                  Nothing
+                 InvisibleQuantification
                  (Just
                     (CxSingle
                        SrcSpanInfo
@@ -1113,6 +1116,7 @@ ParseOk
                    , srcInfoPoints = []
                    }
                  Nothing
+                 InvisibleQuantification
                  (Just
                     (CxSingle
                        SrcSpanInfo

--- a/tests/examples/InjectiveTypeFamilies.hs.parser.golden
+++ b/tests/examples/InjectiveTypeFamilies.hs.parser.golden
@@ -15446,6 +15446,7 @@ ParseOk
                          }
                        "a")
                 ])
+             InvisibleQuantification
              (Just
                 (CxSingle
                    SrcSpanInfo

--- a/tests/examples/MultiCtxt.hs.parser.golden
+++ b/tests/examples/MultiCtxt.hs.parser.golden
@@ -65,6 +65,7 @@ ParseOk
                , srcInfoPoints = []
                }
              Nothing
+             InvisibleQuantification
              (Just
                 (CxSingle
                    SrcSpanInfo
@@ -126,6 +127,7 @@ ParseOk
                      , srcInfoPoints = []
                      }
                    Nothing
+                   InvisibleQuantification
                    (Just
                       (CxSingle
                          SrcSpanInfo

--- a/tests/examples/MultiParam.hs.parser.golden
+++ b/tests/examples/MultiParam.hs.parser.golden
@@ -49,6 +49,7 @@ ParseOk
                , srcInfoPoints = []
                }
              Nothing
+             InvisibleQuantification
              (Just
                 (CxSingle
                    SrcSpanInfo

--- a/tests/examples/OverloadedLabels.hs.parser.golden
+++ b/tests/examples/OverloadedLabels.hs.parser.golden
@@ -417,6 +417,7 @@ ParseOk
                , srcInfoPoints = []
                }
              Nothing
+             InvisibleQuantification
              (Just
                 (CxSingle
                    SrcSpanInfo

--- a/tests/examples/PartialSignatures.hs.parser.golden
+++ b/tests/examples/PartialSignatures.hs.parser.golden
@@ -4016,6 +4016,7 @@ ParseOk
                , srcInfoPoints = []
                }
              Nothing
+             InvisibleQuantification
              (Just
                 (CxSingle
                    SrcSpanInfo
@@ -4109,6 +4110,7 @@ ParseOk
                , srcInfoPoints = []
                }
              Nothing
+             InvisibleQuantification
              (Just
                 (CxSingle
                    SrcSpanInfo
@@ -4448,6 +4450,7 @@ ParseOk
                , srcInfoPoints = []
                }
              Nothing
+             InvisibleQuantification
              (Just
                 (CxSingle
                    SrcSpanInfo
@@ -5784,6 +5787,7 @@ ParseOk
                , srcInfoPoints = []
                }
              Nothing
+             InvisibleQuantification
              (Just
                 (CxSingle
                    SrcSpanInfo
@@ -6115,6 +6119,7 @@ ParseOk
                , srcInfoPoints = []
                }
              Nothing
+             InvisibleQuantification
              (Just
                 (CxTuple
                    SrcSpanInfo
@@ -6332,6 +6337,7 @@ ParseOk
                , srcInfoPoints = []
                }
              Nothing
+             InvisibleQuantification
              (Just
                 (CxTuple
                    SrcSpanInfo
@@ -6594,6 +6600,7 @@ ParseOk
                , srcInfoPoints = []
                }
              Nothing
+             InvisibleQuantification
              (Just
                 (CxTuple
                    SrcSpanInfo
@@ -6811,6 +6818,7 @@ ParseOk
                , srcInfoPoints = []
                }
              Nothing
+             InvisibleQuantification
              (Just
                 (CxTuple
                    SrcSpanInfo
@@ -7118,6 +7126,7 @@ ParseOk
                , srcInfoPoints = []
                }
              Nothing
+             InvisibleQuantification
              (Just
                 (CxSingle
                    SrcSpanInfo
@@ -7223,6 +7232,7 @@ ParseOk
                , srcInfoPoints = []
                }
              Nothing
+             InvisibleQuantification
              (Just
                 (CxSingle
                    SrcSpanInfo
@@ -7322,6 +7332,7 @@ ParseOk
                , srcInfoPoints = []
                }
              Nothing
+             InvisibleQuantification
              (Just
                 (CxSingle
                    SrcSpanInfo
@@ -7438,6 +7449,7 @@ ParseOk
                          }
                        "a")
                 ])
+             InvisibleQuantification
              Nothing
              (TyFun
                 SrcSpanInfo
@@ -7718,6 +7730,7 @@ ParseOk
                                }
                              "a")
                       ])
+                   InvisibleQuantification
                    Nothing
                    (TyFun
                       SrcSpanInfo
@@ -8026,6 +8039,7 @@ ParseOk
                                }
                              "a")
                       ])
+                   InvisibleQuantification
                    Nothing
                    (TyFun
                       SrcSpanInfo
@@ -8350,6 +8364,7 @@ ParseOk
                          }
                        "a")
                 ])
+             InvisibleQuantification
              Nothing
              (TyFun
                 SrcSpanInfo
@@ -9993,6 +10008,7 @@ ParseOk
                          }
                        "a")
                 ])
+             InvisibleQuantification
              Nothing
              (TyFun
                 SrcSpanInfo
@@ -10670,6 +10686,7 @@ ParseOk
                , srcInfoPoints = []
                }
              Nothing
+             InvisibleQuantification
              (Just
                 (CxSingle
                    SrcSpanInfo
@@ -12503,6 +12520,7 @@ ParseOk
                , srcInfoPoints = []
                }
              Nothing
+             InvisibleQuantification
              (Just
                 (CxSingle
                    SrcSpanInfo
@@ -13305,6 +13323,7 @@ ParseOk
                , srcInfoPoints = []
                }
              Nothing
+             InvisibleQuantification
              (Just
                 (CxSingle
                    SrcSpanInfo
@@ -14391,6 +14410,7 @@ ParseOk
                , srcInfoPoints = []
                }
              Nothing
+             InvisibleQuantification
              (Just
                 (CxSingle
                    SrcSpanInfo
@@ -16258,6 +16278,7 @@ ParseOk
                , srcInfoPoints = []
                }
              Nothing
+             InvisibleQuantification
              (Just
                 (CxTuple
                    SrcSpanInfo

--- a/tests/examples/PatternSynonyms3.hs.parser.golden
+++ b/tests/examples/PatternSynonyms3.hs.parser.golden
@@ -798,6 +798,7 @@ ParseOk
                , srcInfoPoints = []
                }
              Nothing
+             InvisibleQuantification
              (Just
                 (CxSingle
                    SrcSpanInfo
@@ -1196,6 +1197,7 @@ ParseOk
                , srcInfoPoints = []
                }
              Nothing
+             InvisibleQuantification
              (Just
                 (CxSingle
                    SrcSpanInfo

--- a/tests/examples/QuantifiedConstraints.hs.parser.golden
+++ b/tests/examples/QuantifiedConstraints.hs.parser.golden
@@ -111,6 +111,7 @@ ParseOk
                                      }
                                    "a")
                             ])
+                         InvisibleQuantification
                          Nothing
                          (TyApp
                             SrcSpanInfo

--- a/tests/examples/QuasiQuoteSplice.hs.parser.golden
+++ b/tests/examples/QuasiQuoteSplice.hs.parser.golden
@@ -351,6 +351,7 @@ ParseOk
                                            }
                                          "m")
                                   ])
+                               InvisibleQuantification
                                Nothing
                                (TyApp
                                   SrcSpanInfo

--- a/tests/examples/RCategory.hs.parser.golden
+++ b/tests/examples/RCategory.hs.parser.golden
@@ -328,6 +328,7 @@ ParseOk
                          , srcInfoPoints = []
                          }
                        Nothing
+                       InvisibleQuantification
                        (Just
                           (CxSingle
                              SrcSpanInfo
@@ -498,6 +499,7 @@ ParseOk
                          , srcInfoPoints = []
                          }
                        Nothing
+                       InvisibleQuantification
                        (Just
                           (CxTuple
                              SrcSpanInfo
@@ -1440,6 +1442,7 @@ ParseOk
                , srcInfoPoints = []
                }
              Nothing
+             InvisibleQuantification
              (Just
                 (CxTuple
                    SrcSpanInfo
@@ -1932,6 +1935,7 @@ ParseOk
                , srcInfoPoints = []
                }
              Nothing
+             InvisibleQuantification
              (Just
                 (CxTuple
                    SrcSpanInfo

--- a/tests/examples/Rules.hs.parser.golden
+++ b/tests/examples/Rules.hs.parser.golden
@@ -70,6 +70,7 @@ ParseOk
                                     }
                                   "b")
                            ])
+                        InvisibleQuantification
                         Nothing
                         (TyFun
                            SrcSpanInfo

--- a/tests/examples/ScopedTypeVariables.hs.parser.golden
+++ b/tests/examples/ScopedTypeVariables.hs.parser.golden
@@ -355,6 +355,7 @@ ParseOk
                          }
                        "x")
                 ])
+             InvisibleQuantification
              (Just
                 (CxSingle
                    SrcSpanInfo

--- a/tests/examples/SingleClassAsst.hs.parser.golden
+++ b/tests/examples/SingleClassAsst.hs.parser.golden
@@ -53,6 +53,7 @@ ParseOk
                , srcInfoPoints = []
                }
              Nothing
+             InvisibleQuantification
              (Just
                 (CxSingle
                    SrcSpanInfo

--- a/tests/examples/SpecializePhaseControl.hs.parser.golden
+++ b/tests/examples/SpecializePhaseControl.hs.parser.golden
@@ -64,6 +64,7 @@ ParseOk
                     [ SrcSpan "tests/examples/SpecializePhaseControl.hs" 2 17 2 19 ]
                 }
               Nothing
+              InvisibleQuantification
               Nothing
               (TyFun
                  SrcSpanInfo
@@ -144,6 +145,7 @@ ParseOk
                     [ SrcSpan "tests/examples/SpecializePhaseControl.hs" 3 17 3 19 ]
                 }
               Nothing
+              InvisibleQuantification
               Nothing
               (TyFun
                  SrcSpanInfo
@@ -224,6 +226,7 @@ ParseOk
                     [ SrcSpan "tests/examples/SpecializePhaseControl.hs" 4 13 4 15 ]
                 }
               Nothing
+              InvisibleQuantification
               Nothing
               (TyFun
                  SrcSpanInfo
@@ -319,6 +322,7 @@ ParseOk
                , srcInfoPoints = []
                }
              Nothing
+             InvisibleQuantification
              (Just
                 (CxTuple
                    SrcSpanInfo
@@ -566,6 +570,7 @@ ParseOk
                     [ SrcSpan "tests/examples/SpecializePhaseControl.hs" 10 17 10 19 ]
                 }
               Nothing
+              InvisibleQuantification
               Nothing
               (TyFun
                  SrcSpanInfo
@@ -646,6 +651,7 @@ ParseOk
                     [ SrcSpan "tests/examples/SpecializePhaseControl.hs" 11 17 11 19 ]
                 }
               Nothing
+              InvisibleQuantification
               Nothing
               (TyFun
                  SrcSpanInfo
@@ -726,6 +732,7 @@ ParseOk
                     [ SrcSpan "tests/examples/SpecializePhaseControl.hs" 12 13 12 15 ]
                 }
               Nothing
+              InvisibleQuantification
               Nothing
               (TyFun
                  SrcSpanInfo
@@ -821,6 +828,7 @@ ParseOk
                , srcInfoPoints = []
                }
              Nothing
+             InvisibleQuantification
              (Just
                 (CxTuple
                    SrcSpanInfo

--- a/tests/examples/TypeEqualityParen.hs.parser.golden
+++ b/tests/examples/TypeEqualityParen.hs.parser.golden
@@ -55,6 +55,7 @@ ParseOk
                , srcInfoPoints = []
                }
              Nothing
+             InvisibleQuantification
              (Just
                 (CxTuple
                    SrcSpanInfo

--- a/tests/examples/TypeOperatorsTest.hs.parser.golden
+++ b/tests/examples/TypeOperatorsTest.hs.parser.golden
@@ -71,6 +71,7 @@ ParseOk
                , srcInfoPoints = []
                }
              Nothing
+             InvisibleQuantification
              (Just
                 (CxSingle
                    SrcSpanInfo

--- a/tests/examples/Unicode.hs.parser.golden
+++ b/tests/examples/Unicode.hs.parser.golden
@@ -3737,6 +3737,7 @@ ParseOk
                , srcInfoPoints = []
                }
              Nothing
+             InvisibleQuantification
              (Just
                 (CxTuple
                    SrcSpanInfo

--- a/tests/examples/UnicodeSyntax.hs.parser.golden
+++ b/tests/examples/UnicodeSyntax.hs.parser.golden
@@ -581,6 +581,7 @@ ParseOk
                          }
                        "a")
                 ])
+             InvisibleQuantification
              Nothing
              (TyFun
                 SrcSpanInfo

--- a/tests/examples/Vta1.hs.parser.golden
+++ b/tests/examples/Vta1.hs.parser.golden
@@ -2159,6 +2159,7 @@ ParseOk
                          }
                        "b")
                 ])
+             InvisibleQuantification
              Nothing
              (TyFun
                 SrcSpanInfo
@@ -2194,6 +2195,7 @@ ParseOk
                                   }
                                 "a")
                          ])
+                      InvisibleQuantification
                       Nothing
                       (TyFun
                          SrcSpanInfo
@@ -2587,6 +2589,7 @@ ParseOk
                          }
                        "a")
                 ])
+             InvisibleQuantification
              Nothing
              (TyFun
                 SrcSpanInfo
@@ -2633,6 +2636,7 @@ ParseOk
                                   }
                                 "b")
                          ])
+                      InvisibleQuantification
                       Nothing
                       (TyFun
                          SrcSpanInfo
@@ -3146,6 +3150,7 @@ ParseOk
                          }
                        "a")
                 ])
+             InvisibleQuantification
              (Just
                 (CxSingle
                    SrcSpanInfo
@@ -3210,6 +3215,7 @@ ParseOk
                             }
                           "b")
                    ])
+                InvisibleQuantification
                 Nothing
                 (TyFun
                    SrcSpanInfo
@@ -3420,6 +3426,7 @@ ParseOk
                                            }
                                          "a")
                                   ])
+                               InvisibleQuantification
                                (Just
                                   (CxSingle
                                      SrcSpanInfo
@@ -3498,6 +3505,7 @@ ParseOk
                                               }
                                             "b")
                                      ])
+                                  InvisibleQuantification
                                   Nothing
                                   (TyFun
                                      SrcSpanInfo
@@ -4865,6 +4873,7 @@ ParseOk
                                     }
                                   "a")
                            ])
+                        InvisibleQuantification
                         (Just
                            (CxSingle
                               SrcSpanInfo
@@ -5147,6 +5156,7 @@ ParseOk
                             , srcInfoPoints = []
                             }))
                 ])
+             InvisibleQuantification
              Nothing
              (TyFun
                 SrcSpanInfo

--- a/tests/examples/Vta2.hs.parser.golden
+++ b/tests/examples/Vta2.hs.parser.golden
@@ -122,6 +122,7 @@ ParseOk
                                   }
                                 "a")
                          ])
+                      InvisibleQuantification
                       Nothing
                       (TyFun
                          SrcSpanInfo
@@ -546,6 +547,7 @@ ParseOk
                                   }
                                 "a")
                          ])
+                      InvisibleQuantification
                       Nothing
                       (TyFun
                          SrcSpanInfo


### PR DESCRIPTION
Support two features for GHC 8.10:

* StandAloneKindSignatures (example: `type Maybe :: Type -> Type`)
* Visible forall quantification (example: `forall k -> k -> Type`, note use of `->` instead of `.` after `forall`)

