### PR TITLE
Strict-read of file contents and calling hClose

### DIFF
--- a/src/Language/Haskell/Exts.hs
+++ b/src/Language/Haskell/Exts.hs
@@ -160,7 +160,8 @@ readUTF8File :: FilePath -> IO String
 readUTF8File fp = do
   h <- openFile fp ReadMode
   hSetEncoding h utf8
-  hGetContents h
+  c <- hGetContents h
+  close h
 
 -- | Converts a parse result with comments to a parse result with comments and
 --   unknown pragmas.

--- a/src/Language/Haskell/Exts.hs
+++ b/src/Language/Haskell/Exts.hs
@@ -160,8 +160,9 @@ readUTF8File :: FilePath -> IO String
 readUTF8File fp = do
   h <- openFile fp ReadMode
   hSetEncoding h utf8
-  c <- hGetContents h
-  close h
+  c <- hGetContents h >>= \s -> length s `seq` return s
+  hClose h
+  return c
 
 -- | Converts a parse result with comments to a parse result with comments and
 --   unknown pragmas.

--- a/tests/Runner.hs
+++ b/tests/Runner.hs
@@ -180,7 +180,9 @@ commentsTests dir = testGroup "Comments tests" $ do
 readUTF8File :: FilePath -> IO String
 readUTF8File fp = openFile fp ReadMode >>= \h -> do
         hSetEncoding h utf8
-        hGetContents h
+        c <- hGetContents h >>= \s -> length s `seq` return s
+        hClose h
+        return c
 
 parseUTF8FileWithComments :: ParseMode -> FilePath -> IO (ParseResult (Module SrcSpanInfo, [Comment]))
 parseUTF8FileWithComments p fp = readUTF8File fp >>= (return . parseFileContentsWithComments p)


### PR DESCRIPTION
This minor fix addresses #459. Functions affected are `readUTF8File` in two separate places.