### PR TITLE
Adding a "type" prefix when printing type operator import specs with import lists

### DIFF
--- a/src/Language/Haskell/Exts/Pretty.hs
+++ b/src/Language/Haskell/Exts/Pretty.hs
@@ -367,12 +367,18 @@ instance Pretty (ImportSpecList l) where
             (if b then text "hiding" else empty)
                 <+> parenList (map pretty ispecs)
 
-instance  Pretty (ImportSpec l) where
+instance Pretty (ImportSpec l) where
         pretty (IVar _ name  )              = pretty name
         pretty (IAbs _ ns name)             = pretty ns <+> pretty name
-        pretty (IThingAll _ name)           = pretty name <> text "(..)"
-        pretty (IThingWith _ name nameList) =
-                pretty name <> (parenList . map pretty $ nameList)
+        pretty (IThingAll _ name) = let rest = pretty name <> text "(..)" in
+          case name of
+            -- if it's a symbol, append a "type" prefix to the beginning
+            (Symbol _ _)                     -> pretty (TypeNamespace {}) <+> rest
+            (Ident  _ _)                     -> rest
+        pretty (IThingWith _ name nameList) = let rest = pretty name <> (parenList . map pretty $ nameList) in
+          case name of
+            (Symbol _ _)                     -> pretty (TypeNamespace {}) <+> rest
+            (Ident  _ _)                     -> rest
 
 instance  Pretty (TypeEqn l) where
         pretty (TypeEqn _ pat eqn) = mySep [pretty pat, equals, pretty eqn]


### PR DESCRIPTION
When importing type operators, GHC expects the `ExplicitNamespaces` pragma (which `TypeOperators` implies) and the `type` prefix before the import spec.

But this did not happen when the `ImportSpec` was given with the constructor `IThingWith` or `IThingAll` since they do not contain namespaces. I've changed the `Pretty` instance so that they get this prefix if the parent is an operator.

An example:

```hs
{-# LANGUAGE TypeOperators #-}

module TypeOperatorImport where

import TypeOperatorExport ((&&&), type (***)((:*:)), type (<))

test1 :: (<) () Bool
test1 = ()

test2 :: Bool -> Bool -> (***) () Bool
test2 b1 b2 = () :*: (b1 &&& b2)
```

I've tried to create tests for this, but I got `Parse error` messages for the `((:*:))` part.

Thank you in advance:)