### PR TITLE
MonR: remove unneccessary and noncanonical `return` definitions

### DIFF
--- a/src/Language/Haskell/Exts/ExactPrint.hs
+++ b/src/Language/Haskell/Exts/ExactPrint.hs
@@ -47,11 +47,10 @@ instance Functor EP where
   fmap = liftM
 
 instance Applicative EP where
-  pure = return
+  pure x = EP $ \l cs -> (x, l, cs, id)
   (<*>) = ap
 
 instance Monad EP where
-  return x = EP $ \l cs -> (x, l, cs, id)
 
   EP m >>= k = EP $ \l0 c0 -> let
         (a, l1, c1, s1) = m l0 c0

--- a/src/Language/Haskell/Exts/ParseMonad.hs
+++ b/src/Language/Haskell/Exts/ParseMonad.hs
@@ -98,7 +98,6 @@ instance Applicative ParseResult where
   ParseFailed loc msg <*> _ = ParseFailed loc msg
 
 instance Monad ParseResult where
-  return = ParseOk
 #if !MIN_VERSION_base(4,13,0)
   fail = Fail.fail
 #endif
@@ -242,11 +241,10 @@ instance Functor P where
   fmap = liftM
 
 instance Applicative P where
-  pure = return
+  pure a = P $ \_i _x _y _l _ch s _m -> Ok s a
   (<*>) = ap
 
 instance Monad P where
-    return a = P $ \_i _x _y _l _ch s _m -> Ok s a
     P m >>= k = P $ \i x y l ch s mode ->
         case m i x y l ch s mode of
             Failed loc msg -> Failed loc msg
@@ -354,11 +352,10 @@ instance Functor (Lex r) where
     fmap = liftM
 
 instance Applicative (Lex r) where
-    pure = return
+    pure a = Lex $ \k -> k a
     (<*>) = ap
 
 instance Monad (Lex r) where
-    return a = Lex $ \k -> k a
     Lex v >>= f = Lex $ \k -> v (\a -> runL (f a) k)
     Lex v >> Lex w = Lex $ \k -> v (\_ -> w k)
 #if !MIN_VERSION_base(4,13,0)

--- a/src/Language/Haskell/Exts/ParseMonad.hs
+++ b/src/Language/Haskell/Exts/ParseMonad.hs
@@ -113,7 +113,6 @@ instance Semigroup m => Semigroup (ParseResult m) where
 
 instance ( Monoid m , Semigroup m) => Monoid (ParseResult m) where
   mempty = ParseOk mempty
-  mappend = (<>)
 
 -- internal version
 data ParseStatus a = Ok ParseState a | Failed SrcLoc String

--- a/src/Language/Haskell/Exts/Pretty.hs
+++ b/src/Language/Haskell/Exts/Pretty.hs
@@ -117,7 +117,6 @@ instance Applicative (DocM s) where
 instance Monad (DocM s) where
         (>>=) = thenDocM
         (>>) = then_DocM
-        return = retDocM
 
 {-# INLINE thenDocM #-}
 {-# INLINE then_DocM #-}


### PR DESCRIPTION
As part of my work on https://github.com/haskell/core-libraries-committee/issues/418, I found some `Monad` instances which have `return` defined for them, as well as `mappend` definition. This PR removes these `return` definitions and updates the `pure` definitions to be complete, and removes one `mappend` definition.

cc @Bodigrim
